### PR TITLE
Add local-first backend implementation (local-dev) with explicit plugin/decorator bootstrap

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Arcadia Clash is a competitive tournament hub for managing brackets, teams, and live matches."
+    />
+    <meta property="og:title" content="Arcadia Clash - Page not found" />
+    <meta
+      property="og:description"
+      content="We couldn’t find that page, but Arcadia Clash has plenty of tournaments to explore."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://arcadiaclash.gg/404" />
+    <meta property="og:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Arcadia Clash - Page not found" />
+    <meta
+      name="twitter:description"
+      content="We couldn’t find that page, but Arcadia Clash has plenty of tournaments to explore."
+    />
+    <meta name="twitter:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <title>Arcadia Clash - Page not found</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ARCADIA-0001"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('config', 'G-ARCADIA-0001');
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav">
+        <a class="logo" href="index.html">
+          <span class="logo-mark">AC</span>
+          <span class="logo-text">Arcadia Clash</span>
+        </a>
+        <div class="nav-links">
+          <a href="index.html#features">Features</a>
+          <a href="index.html#brackets">Brackets</a>
+          <a href="index.html#schedule">Schedule</a>
+          <a href="index.html#community">Community</a>
+          <a href="signup.html">Tournament Sign Up</a>
+          <a href="support.html">Support</a>
+        </div>
+        <div class="auth-status" data-auth-status>
+          <a class="btn ghost" href="login.html" data-auth-signin>Sign In</a>
+          <div class="auth-user is-hidden" data-auth-user></div>
+          <button class="btn ghost is-hidden" type="button" data-auth-logout>Sign Out</button>
+        </div>
+      </nav>
+    </header>
+
+    <main class="auth">
+      <section class="auth-hero">
+        <p class="tag">404 · Lost in the brackets</p>
+        <h1>We couldn’t find that page.</h1>
+        <p class="subhead">
+          The link may have been moved, or the match has already ended. Jump back to the tournament
+          hub to keep exploring.
+        </p>
+      </section>
+
+      <section class="auth-card">
+        <h2>Quick links</h2>
+        <p class="form-note">Try one of these pages to get back on track.</p>
+        <div class="hero-actions">
+          <a class="btn primary" href="index.html">Back to home</a>
+          <a class="btn secondary" href="schedule.html">View schedule</a>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div>
+        <h3>Need help?</h3>
+        <p>Support can guide you to the right tournament info.</p>
+      </div>
+      <a class="btn ghost" href="support.html">Contact support</a>
+    </footer>
+
+    <script src="auth.js"></script>
+  </body>
+</html>

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,58 @@
+# Deployment Guide
+
+This project currently ships a static frontend (HTML/CSS/JS) and a Fastify backend. The fastest
+path to deployment is to host the static site on a CDN and the API on a Node-friendly platform.
+
+## Frontend (Static HTML)
+
+### Option A: Vercel
+1. Create a new Vercel project and import this repository.
+2. Set the **Framework Preset** to **Other** (static).
+3. Set **Build Command** to `None`.
+4. Set **Output Directory** to `/` (root).
+5. Deploy.
+
+### Option B: Netlify
+1. Create a new Netlify site from Git.
+2. Set **Build Command** to `None`.
+3. Set **Publish Directory** to `/`.
+4. Deploy.
+
+## Backend (Fastify API)
+
+### Option A: Render (recommended starter)
+1. Create a new **Web Service**.
+2. Set the **Root Directory** to `server`.
+3. Set the **Build Command** to `npm install`.
+4. Set the **Start Command** to `npm start`.
+5. Add the environment variables from `server/.env.example`.
+
+### Option B: Fly.io
+1. Initialize a Fly app inside `server/`.
+2. Set environment variables from `server/.env.example`.
+3. Deploy using `fly deploy`.
+
+## Environment Variables
+
+See `server/.env.example` for the required variables. At a minimum, set:
+- `JWT_SECRET` (required)
+- `COOKIE_SECRET` (required)
+- `DB_PATH` (required for local/volume storage)
+- `NODE_ENV=production`
+
+## Analytics
+
+Replace the placeholder analytics ID (`G-ARCADIA-0001`) in the HTML files with your production
+Google Analytics measurement ID before deploying the frontend.
+
+## Database Notes
+
+SQLite is great for local development. For production, consider migrating to a managed Postgres
+service (Supabase, Neon, RDS). When you switch, replace the SQLite layer with a Postgres client and
+update the database initialization accordingly.
+
+## Post-Deployment Checklist
+
+- Verify `/health` and `/api/status` respond on the backend URL.
+- Confirm `/api/auth/login` issues tokens and `/api/auth/session` returns the profile.
+- Update frontend fetch URLs if the API runs on a different domain (CORS).

--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 My First Go at Online Learning
 This is Fascinating!
 I didn't think I would enjoy being curious about programming this much!
+
+## Deployment
+
+See [`DEPLOYMENT.md`](DEPLOYMENT.md) for hosting and deployment guidance for the frontend and backend.

--- a/admin-console.html
+++ b/admin-console.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Arcadia Clash is a competitive tournament hub for managing brackets, teams, and live matches." />
+    <meta property="og:title" content="Arcadia Clash - Tournament Hub" />
+    <meta property="og:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://arcadiaclash.gg/" />
+    <meta property="og:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Arcadia Clash - Tournament Hub" />
+    <meta name="twitter:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta name="twitter:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <title>Arcadia Clash - Admin Console</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ARCADIA-0001"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-ARCADIA-0001");
+    </script>
+  </head>
+  <body data-requires-auth="true" data-required-roles="Admin/Staff,Organizer">
+    <header class="site-header">
+      <nav class="nav">
+        <a class="logo" href="index.html">
+          <span class="logo-mark">AC</span>
+          <span class="logo-text">Arcadia Clash</span>
+        </a>
+        <div class="nav-links">
+          <a href="index.html#features">Features</a>
+          <a href="index.html#brackets">Brackets</a>
+          <a href="index.html#schedule">Schedule</a>
+          <a href="index.html#community">Community</a>
+          <a href="signup.html">Tournament Sign Up</a>
+          <a href="user-signup.html">User Sign Up</a>
+          <a href="schedule.html">Schedule List</a>
+          <a href="team-management.html">Team Management</a>
+          <a href="player-dashboard.html">Player Dashboard</a>
+          <a href="match-center.html">Match Center</a>
+          <a href="player-profile.html">Player Profile</a>
+          <a href="team-profile.html">Team Profile</a>
+          <a href="event-detail.html">Event Detail</a>
+          <a href="tickets.html">Tickets</a>
+          <a href="support.html">Support</a>
+          <a href="rules.html">Rules</a>
+          <a href="standings.html">Standings</a>
+          <a href="admin-console.html" class="active">Admin Console</a>
+          <a href="seeding.html">Seeding</a>
+          <a href="faq.html">FAQ</a>
+        </div>
+        <div class="auth-status" data-auth-status>
+          <a class="btn ghost" href="login.html" data-auth-signin>Sign In</a>
+          <div class="auth-user is-hidden" data-auth-user></div>
+          <button class="btn ghost is-hidden" type="button" data-auth-logout>Sign Out</button>
+        </div>
+      </nav>
+    </header>
+
+    <main class="admin-console">
+      <section class="panel auth-gate is-hidden" data-auth-gate>
+        <h2>Organizer access required</h2>
+        <p class="subhead">
+          Sign in with an organizer or admin account to manage approvals, brackets, and broadcasts.
+        </p>
+        <a class="btn primary" href="login.html">Sign in to continue</a>
+      </section>
+      <div class="admin-protected" data-auth-protected>
+        <section class="admin-hero">
+          <div>
+            <p class="tag">Organizer Tools</p>
+            <h1>Admin console</h1>
+            <p class="subhead">
+              Approve teams, lock brackets, and coordinate broadcasts with one streamlined organizer
+              dashboard.
+            </p>
+            <p class="helper-text" id="admin-auth-status" aria-live="polite"></p>
+          </div>
+          <div class="admin-actions">
+            <button class="btn primary">Publish update</button>
+            <button class="btn secondary">Open incident log</button>
+          </div>
+        </section>
+
+      <section class="admin-grid">
+        <div class="panel" data-required-roles="Admin/Staff">
+          <div class="panel-header">
+            <h2>Pending approvals</h2>
+            <button class="btn ghost">View all</button>
+          </div>
+          <div class="approval-list">
+            <div class="approval-card">
+              <div>
+                <h3>Neon Nautilus</h3>
+                <p>Roster lock request · 4 starters, 1 sub</p>
+              </div>
+              <div class="approval-actions">
+                <button class="btn secondary">Approve</button>
+                <button class="btn ghost">Review</button>
+              </div>
+            </div>
+            <div class="approval-card">
+              <div>
+                <h3>Lagoon Legends</h3>
+                <p>Logo update · awaiting asset review</p>
+              </div>
+              <div class="approval-actions">
+                <button class="btn secondary">Approve</button>
+                <button class="btn ghost">Review</button>
+              </div>
+            </div>
+            <div class="approval-card">
+              <div>
+                <h3>Volt Tide</h3>
+                <p>Emergency substitute request</p>
+              </div>
+              <div class="approval-actions">
+                <button class="btn secondary">Approve</button>
+                <button class="btn ghost">Review</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="panel" data-required-roles="Admin/Staff,Organizer">
+          <div class="panel-header">
+            <h2>Broadcast checklist</h2>
+            <button class="btn ghost">Assign</button>
+          </div>
+          <ul class="checklist">
+            <li><span class="status-pill open">On track</span> Stream overlays uploaded</li>
+            <li><span class="status-pill">Pending</span> Casters confirmed</li>
+            <li><span class="status-pill open">On track</span> Replay backups enabled</li>
+            <li><span class="status-pill">Pending</span> Sponsor read locked</li>
+          </ul>
+          <button class="btn secondary">Open rundown</button>
+        </div>
+      </section>
+
+      <section class="admin-grid">
+        <div class="panel" data-required-roles="Admin/Staff,Organizer">
+          <div class="panel-header">
+            <h2>Bracket control</h2>
+            <button class="btn ghost">Sync</button>
+          </div>
+          <div class="control-grid">
+            <div>
+              <h3>Bracket status</h3>
+              <p>Seeding locked · Publish in 3 hours</p>
+            </div>
+            <div>
+              <h3>Reports</h3>
+              <p>2 open disputes</p>
+            </div>
+            <div>
+              <h3>Match room</h3>
+              <p>12 rooms active</p>
+            </div>
+          </div>
+          <button class="btn primary">Lock bracket</button>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Incident log</h2>
+            <button class="btn ghost">Export</button>
+          </div>
+          <div class="incident-list">
+            <div>
+              <h3>Network outage - Match 6</h3>
+              <p>Resolved · 2:10 PM</p>
+            </div>
+            <div>
+              <h3>Rules clarification requested</h3>
+              <p>Pending · 1:55 PM</p>
+            </div>
+            <div>
+              <h3>Code of conduct warning</h3>
+              <p>Resolved · 1:40 PM</p>
+            </div>
+          </div>
+          <button class="btn ghost">Open incident room</button>
+        </div>
+      </section>
+
+      <section class="admin-grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Log admin action</h2>
+            <span class="pill">Admin only</span>
+          </div>
+          <form id="admin-action-form" class="stacked-form">
+            <p class="helper-text">Signed-in sessions power admin actions.</p>
+            <label class="field">
+              <span>Action</span>
+              <input type="text" name="action" placeholder="Roster lock approved" required />
+            </label>
+            <label class="field">
+              <span>Target type</span>
+              <input type="text" name="targetType" placeholder="team" />
+            </label>
+            <label class="field">
+              <span>Target ID</span>
+              <input type="number" name="targetId" placeholder="12" />
+            </label>
+            <label class="field">
+              <span>Notes</span>
+              <textarea name="notes" rows="3" placeholder="Optional notes"></textarea>
+            </label>
+            <button class="btn primary" type="submit">Log action</button>
+            <p id="admin-action-status" class="helper-text" role="status"></p>
+          </form>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Create tournament</h2>
+            <span class="pill">Organizer access</span>
+          </div>
+          <form id="admin-tournament-form" class="stacked-form">
+            <p class="helper-text">Signed-in sessions power organizer workflows.</p>
+            <label class="field">
+              <span>Tournament name</span>
+              <input type="text" name="name" placeholder="Spring Showdown" required />
+            </label>
+            <label class="field">
+              <span>Status</span>
+              <input type="text" name="status" placeholder="draft" />
+            </label>
+            <label class="field">
+              <span>Starts at</span>
+              <input type="datetime-local" name="startsAt" />
+            </label>
+            <label class="field">
+              <span>Ends at</span>
+              <input type="datetime-local" name="endsAt" />
+            </label>
+            <button class="btn primary" type="submit">Create tournament</button>
+            <p id="admin-tournament-status" class="helper-text" role="status"></p>
+          </form>
+        </div>
+      </section>
+      </div>
+    </main>
+
+    <footer class="footer">
+      <div>
+        <h3>Need more admin tools?</h3>
+        <p>Invite additional staff or request elevated permissions.</p>
+      </div>
+      <button class="btn primary">Manage staff</button>
+    </footer>
+    <script src="auth.js"></script>
+    <script src="admin-console.js"></script>
+  </body>
+</html>

--- a/admin-console.js
+++ b/admin-console.js
@@ -1,0 +1,117 @@
+const actionForm = document.querySelector('#admin-action-form');
+const actionStatus = document.querySelector('#admin-action-status');
+const tournamentForm = document.querySelector('#admin-tournament-form');
+const tournamentStatus = document.querySelector('#admin-tournament-status');
+const authStatus = document.querySelector('#admin-auth-status');
+
+const authClient = window.ArcadiaAuth;
+
+const setStatus = (element, message, type = 'info') => {
+  if (!element) {
+    return;
+  }
+  element.textContent = message;
+  if (type === 'error' || type === 'success') {
+    element.dataset.status = type;
+  } else {
+    element.removeAttribute('data-status');
+  }
+};
+
+const setAuthStatus = (message, type = 'info') => setStatus(authStatus, message, type);
+
+const updateAccessStatus = (user) => {
+  if (!user) {
+    setAuthStatus('Sign in with an organizer or admin token to unlock admin actions.', 'error');
+    return;
+  }
+
+  const roles = user?.roles ?? [];
+  const hasAccess = roles.includes('Admin/Staff') || roles.includes('Organizer');
+  if (!hasAccess) {
+    setAuthStatus('Access denied. Admin or Organizer role required.', 'error');
+    return;
+  }
+
+  setAuthStatus(`Access confirmed for ${user.displayName}.`, 'success');
+};
+
+if (actionForm) {
+  actionForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!authClient?.getAccessToken()) {
+      setStatus(actionStatus, 'Sign in to log an admin action.', 'error');
+      return;
+    }
+
+    const formData = new FormData(actionForm);
+    const payload = {
+      action: formData.get('action')?.toString().trim(),
+      targetType: formData.get('targetType')?.toString().trim() || null,
+      targetId: formData.get('targetId')?.toString().trim() || null,
+      notes: formData.get('notes')?.toString().trim() || null,
+    };
+
+    const response = await authClient.authenticatedFetch('/api/admin/actions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      setStatus(actionStatus, error?.error ?? 'Unable to log admin action.', 'error');
+      return;
+    }
+
+    actionForm.reset();
+    setStatus(actionStatus, 'Admin action logged.', 'success');
+    authClient?.loadSession();
+  });
+}
+
+if (tournamentForm) {
+  tournamentForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!authClient?.getAccessToken()) {
+      setStatus(tournamentStatus, 'Sign in to create a tournament.', 'error');
+      return;
+    }
+
+    const formData = new FormData(tournamentForm);
+    const payload = {
+      name: formData.get('name')?.toString().trim(),
+      status: formData.get('status')?.toString().trim() || 'draft',
+      startsAt: formData.get('startsAt')?.toString() || null,
+      endsAt: formData.get('endsAt')?.toString() || null,
+    };
+
+    const response = await authClient.authenticatedFetch('/api/tournaments', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      setStatus(tournamentStatus, error?.error ?? 'Unable to create tournament.', 'error');
+      return;
+    }
+
+    tournamentForm.reset();
+    setStatus(tournamentStatus, 'Tournament created successfully.', 'success');
+    authClient?.loadSession();
+  });
+}
+
+if (authClient) {
+  authClient.onSessionChange((user) => {
+    updateAccessStatus(user);
+  });
+} else {
+  updateAccessStatus(null);
+}

--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,165 @@
+let currentUser = null;
+let accessToken = null;
+let csrfToken = null;
+const listeners = new Set();
+
+const notify = () => {
+  listeners.forEach((listener) => listener(currentUser));
+};
+
+const getAccessToken = () => accessToken;
+
+const setSession = ({ token, csrfToken: newCsrfToken, user }) => {
+  accessToken = token ?? null;
+  csrfToken = newCsrfToken ?? csrfToken;
+  currentUser = user ?? currentUser;
+  updateAuthUi(currentUser);
+  enforceGuards(currentUser);
+  notify();
+};
+
+const clearSession = () => {
+  accessToken = null;
+  csrfToken = null;
+  currentUser = null;
+};
+
+const onSessionChange = (listener) => {
+  listeners.add(listener);
+  listener(currentUser);
+  return () => listeners.delete(listener);
+};
+
+const updateAuthUi = (user) => {
+  const signInLinks = document.querySelectorAll('[data-auth-signin]');
+  const logoutButtons = document.querySelectorAll('[data-auth-logout]');
+  const userLabels = document.querySelectorAll('[data-auth-user]');
+
+  signInLinks.forEach((link) => link.classList.toggle('is-hidden', Boolean(user)));
+  logoutButtons.forEach((button) => button.classList.toggle('is-hidden', !user));
+
+  userLabels.forEach((label) => {
+    if (user) {
+      label.textContent = `Signed in as ${user.displayName}`;
+      label.classList.remove('is-hidden');
+    } else {
+      label.textContent = '';
+      label.classList.add('is-hidden');
+    }
+  });
+};
+
+const enforceGuards = (user) => {
+  const guardTarget = document.querySelector('[data-requires-auth="true"]');
+  const gate = document.querySelector('[data-auth-gate]');
+  const protectedSection = document.querySelector('[data-auth-protected]');
+
+  const requiredRoles = guardTarget?.dataset.requiredRoles
+    ? guardTarget.dataset.requiredRoles.split(',').map((role) => role.trim())
+    : [];
+
+  if (guardTarget && !user) {
+    if (gate) {
+      gate.classList.remove('is-hidden');
+    }
+    if (protectedSection) {
+      protectedSection.classList.add('is-hidden');
+    }
+    const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    const redirectTo = `login.html?returnTo=${encodeURIComponent(returnTo)}`;
+    window.location.replace(redirectTo);
+    return;
+  }
+
+  const hasRole =
+    requiredRoles.length === 0 ||
+    requiredRoles.some((role) => user?.roles?.includes(role));
+
+  if (guardTarget && gate && protectedSection) {
+    if (hasRole) {
+      gate.classList.add('is-hidden');
+      protectedSection.classList.remove('is-hidden');
+    } else {
+      gate.classList.remove('is-hidden');
+      protectedSection.classList.add('is-hidden');
+    }
+  }
+
+  document.querySelectorAll('[data-required-roles]').forEach((element) => {
+    const roles = element.dataset.requiredRoles
+      .split(',')
+      .map((role) => role.trim())
+      .filter(Boolean);
+    const allowed = roles.some((role) => user?.roles?.includes(role));
+    element.classList.toggle('is-hidden', !allowed);
+  });
+};
+
+const loadSession = async () => {
+  const response = await fetch('/api/auth/session', {
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    clearSession();
+    updateAuthUi(null);
+    enforceGuards(null);
+    notify();
+    return;
+  }
+
+  const data = await response.json();
+  setSession(data);
+};
+
+document.addEventListener('click', (event) => {
+  const target = event.target.closest('[data-auth-logout]');
+  if (!target) {
+    return;
+  }
+  event.preventDefault();
+  fetch('/api/auth/logout', {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': csrfToken ?? '',
+    },
+  })
+    .catch(() => null)
+    .finally(() => {
+      clearSession();
+      updateAuthUi(null);
+      notify();
+      window.location.href = 'index.html';
+    });
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadSession();
+});
+
+window.ArcadiaAuth = {
+  getAccessToken,
+  getCsrfToken: () => csrfToken,
+  setSession,
+  clearSession,
+  loadSession,
+  onSessionChange,
+  authenticatedFetch: async (url, options = {}) => {
+    const token = getAccessToken();
+    const headers = new Headers(options.headers || {});
+    if (token) {
+      headers.set('Authorization', `Bearer ${token}`);
+    }
+    if (options.method && options.method !== 'GET' && csrfToken) {
+      headers.set('X-CSRF-Token', csrfToken);
+    }
+
+    return fetch(url, {
+      credentials: 'include',
+      ...options,
+      headers,
+    });
+  },
+};

--- a/event-detail.html
+++ b/event-detail.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Arcadia Clash is a competitive tournament hub for managing brackets, teams, and live matches." />
+    <meta property="og:title" content="Arcadia Clash - Tournament Hub" />
+    <meta property="og:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://arcadiaclash.gg/" />
+    <meta property="og:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Arcadia Clash - Tournament Hub" />
+    <meta name="twitter:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta name="twitter:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <title>Arcadia Clash - Event Detail</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ARCADIA-0001"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-ARCADIA-0001");
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav">
+        <a class="logo" href="index.html">
+          <span class="logo-mark">AC</span>
+          <span class="logo-text">Arcadia Clash</span>
+        </a>
+        <div class="nav-links">
+          <a href="index.html#features">Features</a>
+          <a href="index.html#brackets">Brackets</a>
+          <a href="index.html#schedule">Schedule</a>
+          <a href="index.html#community">Community</a>
+          <a href="signup.html">Tournament Sign Up</a>
+          <a href="user-signup.html">User Sign Up</a>
+          <a href="schedule.html">Schedule List</a>
+          <a href="team-management.html">Team Management</a>
+          <a href="player-dashboard.html">Player Dashboard</a>
+          <a href="player-profile.html">Player Profile</a>
+          <a href="team-profile.html">Team Profile</a>
+          <a href="match-center.html">Match Center</a>
+          <a href="event-detail.html" class="active">Event Detail</a>
+          <a href="tickets.html">Tickets</a>
+          <a href="support.html">Support</a>
+          <a href="rules.html">Rules</a>
+          <a href="standings.html">Standings</a>
+          <a href="admin-console.html">Admin Console</a>
+          <a href="seeding.html">Seeding</a>
+          <a href="faq.html">FAQ</a>
+        </div>
+        <div class="auth-status" data-auth-status>
+          <a class="btn ghost" href="login.html" data-auth-signin>Sign In</a>
+          <div class="auth-user is-hidden" data-auth-user></div>
+          <button class="btn ghost is-hidden" type="button" data-auth-logout>Sign Out</button>
+        </div>
+      </nav>
+    </header>
+
+    <main class="event-detail">
+      <section class="event-hero">
+        <div>
+          <p class="tag">Splatoon 3 • Major Event</p>
+          <h1>Arcadia Clash Finals Weekend</h1>
+          <p class="subhead">
+            Two-day finals featuring the top 16 teams. Follow the bracket, tune into live streams,
+            and review the official rules for the event.
+          </p>
+        </div>
+        <div class="event-actions">
+          <button class="btn primary">Watch live stream</button>
+          <button class="btn secondary">Add to calendar</button>
+        </div>
+      </section>
+
+      <section class="event-grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Event overview</h2>
+            <button class="btn ghost">Download guide</button>
+          </div>
+          <div class="overview-grid">
+            <div>
+              <h3>Dates</h3>
+              <p>April 18 - 19 · 1:00 PM PT</p>
+            </div>
+            <div>
+              <h3>Location</h3>
+              <p>Grand Arena · Los Angeles</p>
+            </div>
+            <div>
+              <h3>Format</h3>
+              <p>Double elimination · Best of 5</p>
+            </div>
+            <div>
+              <h3>Prize pool</h3>
+              <p>$5,000 · Cash + partner gear</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Stream lineup</h2>
+            <button class="btn ghost">Open Twitch</button>
+          </div>
+          <div class="stream-list">
+            <div>
+              <h3>Stream A</h3>
+              <p>Main stage · @ArcadiaClash</p>
+            </div>
+            <div>
+              <h3>Stream B</h3>
+              <p>Side stage · @ArcadiaClashB</p>
+            </div>
+            <div>
+              <h3>Community</h3>
+              <p>Player POV · Allow 2-min delay</p>
+            </div>
+          </div>
+          <button class="btn secondary">Get stream alerts</button>
+        </div>
+      </section>
+
+      <section class="event-grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Bracket preview</h2>
+            <button class="btn ghost">View full bracket</button>
+          </div>
+          <div class="bracket-preview">
+            <div class="bracket-round">
+              <h3>Quarterfinals</h3>
+              <div class="match">
+                <span>Crimson Circuit</span>
+                <span class="vs">vs</span>
+                <span>Riftwalkers</span>
+              </div>
+              <div class="match">
+                <span>Nebula Wolves</span>
+                <span class="vs">vs</span>
+                <span>Volt Tide</span>
+              </div>
+            </div>
+            <div class="bracket-round">
+              <h3>Semifinals</h3>
+              <div class="match dim">Winner QF1 vs Winner QF2</div>
+              <div class="match dim">Winner QF3 vs Winner QF4</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Weekend schedule</h2>
+            <button class="btn ghost">View full schedule</button>
+          </div>
+          <div class="event-schedule">
+            <div>
+              <h3>Day 1 · April 18</h3>
+              <p>1:00 PM · Quarterfinals</p>
+              <p>4:30 PM · Semifinals</p>
+            </div>
+            <div>
+              <h3>Day 2 · April 19</h3>
+              <p>1:00 PM · Lower bracket</p>
+              <p>5:00 PM · Grand Finals</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="event-grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Rules quick view</h2>
+            <button class="btn ghost">Read full rules</button>
+          </div>
+          <ul class="rules-list">
+            <li>Check-in opens 60 minutes before match time.</li>
+            <li>Disconnects must be reported within 5 minutes.</li>
+            <li>Players may stream with a 2-minute delay.</li>
+            <li>Roster lock occurs 48 hours before the event.</li>
+          </ul>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Attendee checklist</h2>
+            <button class="btn ghost">Download checklist</button>
+          </div>
+          <ul class="checklist">
+            <li><span class="status-pill open">Complete</span> Confirm roster</li>
+            <li><span class="status-pill">Pending</span> Verify gear</li>
+            <li><span class="status-pill">Pending</span> Join Discord briefing</li>
+            <li><span class="status-pill open">Complete</span> Set stream delay</li>
+          </ul>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div>
+        <h3>Ready for finals weekend?</h3>
+        <p>Stay tuned for match alerts and broadcast updates.</p>
+      </div>
+      <button class="btn primary">Enable alerts</button>
+    </footer>
+    <script src="auth.js"></script>
+  </body>
+</html>

--- a/faq.html
+++ b/faq.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Arcadia Clash is a competitive tournament hub for managing brackets, teams, and live matches." />
+    <meta property="og:title" content="Arcadia Clash - Tournament Hub" />
+    <meta property="og:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://arcadiaclash.gg/" />
+    <meta property="og:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Arcadia Clash - Tournament Hub" />
+    <meta name="twitter:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta name="twitter:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <title>Arcadia Clash - Player FAQ</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ARCADIA-0001"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-ARCADIA-0001");
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav">
+        <a class="logo" href="index.html">
+          <span class="logo-mark">AC</span>
+          <span class="logo-text">Arcadia Clash</span>
+        </a>
+        <div class="nav-links">
+          <a href="index.html#features">Features</a>
+          <a href="index.html#brackets">Brackets</a>
+          <a href="index.html#schedule">Schedule</a>
+          <a href="index.html#community">Community</a>
+          <a href="signup.html">Tournament Sign Up</a>
+          <a href="user-signup.html">User Sign Up</a>
+          <a href="schedule.html">Schedule List</a>
+          <a href="seeding.html">Seeding</a>
+          <a href="team-management.html">Team Management</a>
+          <a href="player-dashboard.html">Player Dashboard</a>
+          <a href="player-profile.html">Player Profile</a>
+          <a href="team-profile.html">Team Profile</a>
+          <a href="match-center.html">Match Center</a>
+          <a href="event-detail.html">Event Detail</a>
+          <a href="tickets.html">Tickets</a>
+          <a href="support.html">Support</a>
+          <a href="rules.html">Rules</a>
+          <a href="standings.html">Standings</a>
+          <a href="admin-console.html">Admin Console</a>
+          <a href="faq.html" class="active">FAQ</a>
+        </div>
+        <div class="auth-status" data-auth-status>
+          <a class="btn ghost" href="login.html" data-auth-signin>Sign In</a>
+          <div class="auth-user is-hidden" data-auth-user></div>
+          <button class="btn ghost is-hidden" type="button" data-auth-logout>Sign Out</button>
+        </div>
+      </nav>
+    </header>
+
+    <main class="faq">
+      <section class="faq-hero">
+        <div>
+          <p class="tag">Splatoon 3 • Support</p>
+          <h1>Frequently asked questions</h1>
+          <p class="subhead">
+            Everything players and organizers need to know about joining, streaming, and competing in
+            Arcadia Clash events.
+          </p>
+        </div>
+        <div class="faq-actions">
+          <button class="btn secondary">Submit a question</button>
+          <button class="btn ghost">Contact support</button>
+        </div>
+      </section>
+
+      <section class="faq-grid">
+        <article class="faq-card">
+          <h2>How do I register as a solo player?</h2>
+          <p>
+            Head to the tournament sign up page and choose the individual player form. We will match
+            free agents into balanced squads based on region and role preference.
+          </p>
+        </article>
+        <article class="faq-card">
+          <h2>When do brackets go live?</h2>
+          <p>
+            Brackets publish within 48 hours of registration closing. Follow the seeding page for
+            updates on locks and bracket type.
+          </p>
+        </article>
+        <article class="faq-card">
+          <h2>What equipment is required?</h2>
+          <p>
+            Splatoon 3 events require a Nintendo Switch, stable broadband, and voice chat access via
+            Discord or in-game comms.
+          </p>
+        </article>
+        <article class="faq-card">
+          <h2>Can I update my roster?</h2>
+          <p>
+            Teams can update starters and substitutes until roster lock. After that, only emergency
+            substitutions approved by admins are allowed.
+          </p>
+        </article>
+        <article class="faq-card">
+          <h2>Where do I watch the stream?</h2>
+          <p>
+            Live broadcasts are available on Twitch. Use the live stream card on the front page or
+            the schedule list to jump into the current match.
+          </p>
+        </article>
+        <article class="faq-card">
+          <h2>Who can I contact for support?</h2>
+          <p>
+            Reach us anytime at support@arcadiaclash.gg or through the Discord server linked in the
+            footer of each page.
+          </p>
+        </article>
+      </section>
+
+      <section class="faq-callout">
+        <div>
+          <h2>Still need help?</h2>
+          <p>Join the live support queue and we will help you get match-ready.</p>
+        </div>
+        <button class="btn primary">Join support queue</button>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div>
+        <h3>Stay in the loop</h3>
+        <p>Subscribe to tournament alerts and announcements.</p>
+      </div>
+      <button class="btn secondary">Subscribe</button>
+    </footer>
+    <script src="auth.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Arcadia Clash is a competitive tournament hub for managing brackets, teams, and live matches." />
+    <meta property="og:title" content="Arcadia Clash - Tournament Hub" />
+    <meta property="og:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://arcadiaclash.gg/" />
+    <meta property="og:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Arcadia Clash - Tournament Hub" />
+    <meta name="twitter:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta name="twitter:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <title>Arcadia Clash - Tournament Hub</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ARCADIA-0001"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-ARCADIA-0001");
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav">
+        <a class="logo" href="#">
+          <span class="logo-mark">AC</span>
+          <span class="logo-text">Arcadia Clash</span>
+        </a>
+        <div class="nav-links">
+          <a href="#features" class="active">Features</a>
+          <a href="#brackets">Brackets</a>
+          <a href="#schedule">Schedule</a>
+          <a href="#community">Community</a>
+          <a href="signup.html">Sign Up</a>
+          <a href="user-signup.html">User Sign Up</a>
+          <a href="schedule.html">Schedule List</a>
+          <a href="faq.html">FAQ</a>
+          <a href="team-management.html">Team Management</a>
+          <a href="player-dashboard.html">Player Dashboard</a>
+          <a href="player-profile.html">Player Profile</a>
+          <a href="team-profile.html">Team Profile</a>
+          <a href="match-center.html">Match Center</a>
+          <a href="event-detail.html">Event Detail</a>
+          <a href="tickets.html">Tickets</a>
+          <a href="support.html">Support</a>
+          <a href="rules.html">Rules</a>
+          <a href="standings.html">Standings</a>
+          <a href="admin-console.html">Admin Console</a>
+          <a href="seeding.html">Seeding</a>
+        </div>
+        <div class="auth-status" data-auth-status>
+          <a class="btn ghost" href="login.html" data-auth-signin>Sign In</a>
+          <div class="auth-user is-hidden" data-auth-user></div>
+          <button class="btn ghost is-hidden" type="button" data-auth-logout>Sign Out</button>
+        </div>
+      </nav>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-content">
+          <p class="tag">Season 12 • Registration Open</p>
+          <h1>Run pro-level gaming tournaments in one place.</h1>
+          <p class="subhead">
+            Arcadia Clash helps organizers create brackets, manage teams, and stream matches with a
+            command center built for competitive play.
+          </p>
+          <div class="hero-actions">
+            <button class="btn primary">Create Tournament</button>
+            <button class="btn secondary">View Live Events</button>
+          </div>
+          <div class="hero-stats">
+            <div>
+              <h3>3,200+</h3>
+              <p>Teams registered this month</p>
+            </div>
+            <div>
+              <h3>48 hrs</h3>
+              <p>Avg. setup time saved</p>
+            </div>
+            <div>
+              <h3>98%</h3>
+              <p>Stream uptime last season</p>
+            </div>
+          </div>
+        </div>
+        <div class="hero-card">
+          <div class="card-header">
+            <h2>Tonight's Main Event</h2>
+            <span class="pill">Live</span>
+          </div>
+          <div class="matchup">
+            <div>
+              <p class="team-name">Nebula Wolves</p>
+              <p class="team-rank">#4 Seed</p>
+            </div>
+            <span class="vs">VS</span>
+            <div>
+              <p class="team-name">Crimson Circuit</p>
+              <p class="team-rank">#1 Seed</p>
+            </div>
+          </div>
+          <div class="match-info">
+            <p>Grand Arena • 7:30 PM PT</p>
+            <p>Best of 5 • 24k watching</p>
+          </div>
+          <a class="stream-link" href="https://www.twitch.tv/" aria-label="Watch live on Twitch">
+            <span class="stream-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" role="img" focusable="false">
+                <path
+                  d="M5.5 3.5h15v10.6l-3.8 3.9h-4.4l-2.2 2.1h-2.2v-2.1H4.5V5.1L5.5 3.5zm13.3 1.9H7.1v10h3.4v2.2l2.2-2.2h4.3l2.8-2.8V5.4zm-4.5 3.1h1.6v4.8h-1.6V8.5zm-4.3 0h1.6v4.8h-1.6V8.5z"
+                />
+              </svg>
+            </span>
+            <span>Watch live on Twitch</span>
+          </a>
+          <button class="btn primary full">Watch Stream</button>
+        </div>
+      </section>
+
+      <section id="features" class="features">
+        <h2>Everything a tournament needs.</h2>
+        <div class="feature-grid">
+          <article>
+            <h3>Dynamic brackets</h3>
+            <p>Auto-seeding, double elimination, and live updates that sync with broadcasts.</p>
+          </article>
+          <article>
+            <h3>Team command center</h3>
+            <p>Roster management, check-in reminders, and in-game status updates.</p>
+          </article>
+          <article>
+            <h3>Broadcast overlays</h3>
+            <p>Export overlays, countdowns, and sponsor panels directly to stream suites.</p>
+          </article>
+          <article>
+            <h3>Prize fulfillment</h3>
+            <p>Track payouts, merch drops, and sponsor rewards with one dashboard.</p>
+          </article>
+        </div>
+      </section>
+
+      <section id="brackets" class="brackets">
+        <div>
+          <h2>Live bracket preview</h2>
+          <p>
+            Follow every round in real time. Fans can view team stats, highlights, and MVP picks as
+            the bracket evolves.
+          </p>
+          <button class="btn secondary">Explore the Bracket</button>
+        </div>
+        <div class="bracket-card">
+          <div class="round">
+            <h4>Quarterfinals</h4>
+            <ul>
+              <li>Solstice 3 - 1 Echo Flux</li>
+              <li>Crimson 2 - 0 Nova Bloom</li>
+              <li>Nebula 3 - 2 Ion Rift</li>
+              <li>Volt 2 - 1 Riftwalkers</li>
+            </ul>
+          </div>
+          <div class="round">
+            <h4>Semifinals</h4>
+            <ul>
+              <li>Solstice 1 - 3 Crimson</li>
+              <li>Nebula 2 - 3 Volt</li>
+            </ul>
+          </div>
+          <div class="round">
+            <h4>Finals</h4>
+            <ul>
+              <li>Crimson vs Volt</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section id="schedule" class="schedule">
+        <div class="schedule-header">
+          <h2>Upcoming schedule</h2>
+          <button class="btn ghost">Export Calendar</button>
+        </div>
+        <div class="schedule-grid">
+          <div class="schedule-card">
+            <p class="date">Mar 22</p>
+            <h3>Rookie Sprint</h3>
+            <p>Open qualifier · 64 teams</p>
+          </div>
+          <div class="schedule-card">
+            <p class="date">Apr 02</p>
+            <h3>Midnight Masters</h3>
+            <p>Invite only · 16 teams</p>
+          </div>
+          <div class="schedule-card">
+            <p class="date">Apr 18</p>
+            <h3>Arcadia Clash Finals</h3>
+            <p>LAN event · 6,000 seats</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="community" class="community">
+        <div>
+          <h2>Built for players and fans.</h2>
+          <p>
+            Chat, highlight reels, and fan quests keep the community engaged from registration to
+            the final match.
+          </p>
+        </div>
+        <div class="community-panel">
+          <div>
+            <h3>Live chat & clips</h3>
+            <p>Share moments instantly with integrated clipping and moderation tools.</p>
+          </div>
+          <div>
+            <h3>Creator quests</h3>
+            <p>Reward viewers with badges and merch for watching and sharing streams.</p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div>
+        <h3>Ready to host your next tournament?</h3>
+        <p>Spin up a bracket in minutes and invite teams with a single link.</p>
+      </div>
+      <button class="btn primary">Start Free Trial</button>
+    </footer>
+    <script src="auth.js"></script>
+  </body>
+</html>

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -1,0 +1,51 @@
+# Local-First Implementation
+
+This folder provides a parallel, explicit local-first implementation of the backend that mirrors
+the main API behavior without hidden plugin/decorator registration. It is designed for predictable
+local execution with a single `npm run dev` command.
+
+## Folder Structure
+
+```
+local-dev/
+  README.md
+  backend/
+    local-index.js   # single bootstrap file (plugins + decorators)
+    routes.js        # route definitions only (no plugins/decorators)
+    db.js            # local SQLite schema + init
+    package.json
+    .env.example
+```
+
+## Local Backend Commands
+
+```bash
+cd local-dev/backend
+cp .env.example .env
+npm install
+npm run dev
+```
+
+Backend runs on `http://localhost:3001` and allows frontend requests from
+`http://localhost:4173`.
+
+## Local Frontend Command
+
+From the repo root:
+
+```bash
+python -m http.server 4173
+```
+
+Frontend runs on `http://localhost:4173`.
+
+## Architecture Notes
+
+- **Global setup lives in** `local-dev/backend/local-index.js`:
+  - `@fastify/cors`, `@fastify/cookie`, `@fastify/jwt` plugins
+  - `authenticate` + `requireRoles` decorators
+- **Route logic lives in** `local-dev/backend/routes.js` and does not register plugins or decorators.
+- **Database setup lives in** `local-dev/backend/db.js`.
+
+This keeps plugin/decorator registration centralized and explicit, avoiding hidden coupling or
+implicit execution order.

--- a/local-dev/backend/.env.example
+++ b/local-dev/backend/.env.example
@@ -1,0 +1,7 @@
+NODE_ENV=development
+HOST=0.0.0.0
+PORT=3001
+FRONTEND_ORIGIN=http://localhost:4173
+JWT_SECRET=change-me
+COOKIE_SECRET=change-me
+DB_PATH=./data/arcadia-local.db

--- a/local-dev/backend/db.js
+++ b/local-dev/backend/db.js
@@ -1,0 +1,188 @@
+import { mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import sqlite3 from 'sqlite3';
+import { open } from 'sqlite';
+
+const DEFAULT_DB_PATH = './data/arcadia.db';
+
+export const initDatabase = async () => {
+  const databasePath = process.env.DB_PATH ?? DEFAULT_DB_PATH;
+  const resolvedPath = resolve(databasePath);
+
+  await mkdir(dirname(resolvedPath), { recursive: true });
+
+  const db = await open({
+    filename: resolvedPath,
+    driver: sqlite3.Database,
+  });
+
+  await db.exec(`
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT NOT NULL UNIQUE,
+      display_name TEXT NOT NULL,
+      password_hash TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS teams (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL UNIQUE,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS team_members (
+      team_id INTEGER NOT NULL,
+      user_id INTEGER NOT NULL,
+      role TEXT NOT NULL,
+      joined_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (team_id, user_id),
+      FOREIGN KEY (team_id) REFERENCES teams (id) ON DELETE CASCADE,
+      FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS roles (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL UNIQUE,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS user_roles (
+      user_id INTEGER NOT NULL,
+      role_id INTEGER NOT NULL,
+      assigned_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (user_id, role_id),
+      FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
+      FOREIGN KEY (role_id) REFERENCES roles (id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS tournaments (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'draft',
+      starts_at TEXT,
+      ends_at TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      tournament_id INTEGER NOT NULL,
+      name TEXT NOT NULL,
+      game TEXT NOT NULL,
+      format TEXT NOT NULL,
+      starts_at TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (tournament_id) REFERENCES tournaments (id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS registrations (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      tournament_id INTEGER NOT NULL,
+      team_id INTEGER NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE (tournament_id, team_id),
+      FOREIGN KEY (tournament_id) REFERENCES tournaments (id) ON DELETE CASCADE,
+      FOREIGN KEY (team_id) REFERENCES teams (id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS matches (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      event_id INTEGER NOT NULL,
+      round INTEGER NOT NULL DEFAULT 1,
+      scheduled_at TEXT,
+      status TEXT NOT NULL DEFAULT 'scheduled',
+      home_team_id INTEGER,
+      away_team_id INTEGER,
+      winner_team_id INTEGER,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (event_id) REFERENCES events (id) ON DELETE CASCADE,
+      FOREIGN KEY (home_team_id) REFERENCES teams (id) ON DELETE SET NULL,
+      FOREIGN KEY (away_team_id) REFERENCES teams (id) ON DELETE SET NULL,
+      FOREIGN KEY (winner_team_id) REFERENCES teams (id) ON DELETE SET NULL
+    );
+    CREATE TABLE IF NOT EXISTS match_results (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      match_id INTEGER NOT NULL UNIQUE,
+      home_score INTEGER NOT NULL DEFAULT 0,
+      away_score INTEGER NOT NULL DEFAULT 0,
+      notes TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (match_id) REFERENCES matches (id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS brackets (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      event_id INTEGER NOT NULL,
+      name TEXT NOT NULL,
+      bracket_type TEXT NOT NULL DEFAULT 'single_elimination',
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (event_id) REFERENCES events (id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS support_tickets (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER,
+      subject TEXT NOT NULL,
+      message TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'open',
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE SET NULL
+    );
+    CREATE TABLE IF NOT EXISTS admin_actions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      actor_user_id INTEGER,
+      action TEXT NOT NULL,
+      target_type TEXT,
+      target_id INTEGER,
+      notes TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (actor_user_id) REFERENCES users (id) ON DELETE SET NULL
+    );
+    CREATE TABLE IF NOT EXISTS tournament_signups (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      signup_type TEXT NOT NULL,
+      player_handle TEXT,
+      email TEXT,
+      region TEXT,
+      role_preference TEXT,
+      availability TEXT,
+      team_name TEXT,
+      captain_name TEXT,
+      captain_email TEXT,
+      team_size TEXT,
+      time_slot TEXT,
+      contact_handle TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS standings (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      team_id INTEGER NOT NULL UNIQUE,
+      wins INTEGER NOT NULL DEFAULT 0,
+      losses INTEGER NOT NULL DEFAULT 0,
+      seed_points INTEGER NOT NULL DEFAULT 0,
+      streak TEXT,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (team_id) REFERENCES teams (id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS user_sessions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      refresh_token_hash TEXT NOT NULL UNIQUE,
+      csrf_token TEXT NOT NULL,
+      expires_at TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+    );
+  `);
+
+  const userColumns = await db.all('PRAGMA table_info(users)');
+  const hasPasswordHash = userColumns.some((column) => column.name === 'password_hash');
+  if (!hasPasswordHash) {
+    await db.exec('ALTER TABLE users ADD COLUMN password_hash TEXT;');
+  }
+
+  const roleCount = await db.get('SELECT COUNT(*) AS count FROM roles');
+  if (roleCount?.count === 0) {
+    await db.run('INSERT INTO roles (name) VALUES (?), (?), (?), (?)', [
+      'Player',
+      'Captain',
+      'Organizer',
+      'Admin/Staff',
+    ]);
+  }
+
+  return { db, resolvedPath };
+};

--- a/local-dev/backend/local-index.js
+++ b/local-dev/backend/local-index.js
@@ -1,0 +1,99 @@
+import 'dotenv/config';
+import Fastify from 'fastify';
+import cors from '@fastify/cors';
+import cookie from '@fastify/cookie';
+import jwt from '@fastify/jwt';
+
+import { initDatabase } from './db.js';
+import { registerApiRoutes } from './routes.js';
+
+const app = Fastify({ logger: true });
+
+const registerPlugins = async () => {
+  await app.register(cors, {
+    origin: process.env.FRONTEND_ORIGIN ?? 'http://localhost:4173',
+    credentials: true,
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+  });
+
+  await app.register(cookie, {
+    secret: process.env.COOKIE_SECRET ?? 'dev-cookie-secret-change-me',
+  });
+
+  await app.register(jwt, {
+    secret: process.env.JWT_SECRET ?? 'dev-secret-change-me',
+  });
+};
+
+const registerDecorators = () => {
+  app.decorate('authenticate', async (request, reply) => {
+    try {
+      await request.jwtVerify();
+    } catch (error) {
+      return reply.code(401).send({ error: 'Unauthorized' });
+    }
+  });
+
+  app.decorate('requireRoles', (allowedRoles) => async (request, reply) => {
+    await app.authenticate(request, reply);
+    if (reply.sent) {
+      return;
+    }
+
+    const userId = request.user?.id;
+    if (!userId) {
+      return reply.code(401).send({ error: 'Unauthorized' });
+    }
+
+    const roles = await app.db.all(
+      `SELECT roles.name
+         FROM user_roles
+         JOIN roles ON roles.id = user_roles.role_id
+        WHERE user_roles.user_id = ?`,
+      [userId]
+    );
+    const roleNames = roles.map((role) => role.name);
+    const hasRole = allowedRoles.some((role) => roleNames.includes(role));
+    if (!hasRole) {
+      return reply.code(403).send({ error: 'Forbidden' });
+    }
+  });
+};
+
+const registerRoutes = () => {
+  app.get('/health', async () => ({ status: 'ok' }));
+  app.get('/api/status', async () => ({
+    service: 'Arcadia Clash Backend (Local)',
+    version: '0.1.0-local',
+    environment: process.env.NODE_ENV ?? 'development',
+  }));
+
+  registerApiRoutes(app);
+};
+
+const start = async () => {
+  try {
+    const port = Number(process.env.PORT ?? 3001);
+    const host = process.env.HOST ?? '0.0.0.0';
+
+    const { db, resolvedPath } = await initDatabase();
+    app.decorate('db', db);
+    app.decorate('dbPath', resolvedPath);
+
+    await registerPlugins();
+    registerDecorators();
+    registerRoutes();
+
+    app.addHook('onClose', async (instance) => {
+      await instance.db.close();
+    });
+
+    await app.listen({ port, host });
+    app.log.info(`Local server listening on http://${host}:${port}`);
+  } catch (error) {
+    app.log.error(error);
+    process.exit(1);
+  }
+};
+
+start();

--- a/local-dev/backend/package.json
+++ b/local-dev/backend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "arcadia-clash-local-backend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node local-index.js",
+    "start": "node local-index.js"
+  },
+  "dependencies": {
+    "@fastify/cookie": "^9.2.0",
+    "@fastify/cors": "^8.4.2",
+    "@fastify/jwt": "^7.2.0",
+    "bcryptjs": "^2.4.3",
+    "dotenv": "^16.4.5",
+    "fastify": "^4.26.2",
+    "sqlite": "^5.1.1",
+    "sqlite3": "^5.1.7"
+  }
+}

--- a/local-dev/backend/routes.js
+++ b/local-dev/backend/routes.js
@@ -1,0 +1,716 @@
+import bcrypt from 'bcryptjs';
+import crypto from 'node:crypto';
+
+const requireFields = (payload, fields) => {
+  const missing = fields.filter((field) => !payload?.[field]);
+  if (missing.length) {
+    return { ok: false, missing };
+  }
+  return { ok: true };
+};
+
+export const registerApiRoutes = (app) => {
+  const REFRESH_COOKIE = 'arcadia_refresh';
+  const ACCESS_TOKEN_TTL = '15m';
+  const SESSION_TTL_DAYS = 30;
+
+  const hashToken = (value) => crypto.createHash('sha256').update(value).digest('hex');
+
+  const createSession = async (userId) => {
+    const refreshToken = crypto.randomBytes(48).toString('hex');
+    const csrfToken = crypto.randomBytes(32).toString('hex');
+    const refreshTokenHash = hashToken(refreshToken);
+    const expiresAt = new Date(Date.now() + SESSION_TTL_DAYS * 24 * 60 * 60 * 1000).toISOString();
+
+    await app.db.run(
+      `INSERT INTO user_sessions (user_id, refresh_token_hash, csrf_token, expires_at)
+       VALUES (?, ?, ?, ?)`,
+      [userId, refreshTokenHash, csrfToken, expiresAt]
+    );
+
+    return { refreshToken, csrfToken, expiresAt };
+  };
+
+  const getSessionFromRequest = async (request) => {
+    const refreshToken = request.cookies?.[REFRESH_COOKIE];
+    if (!refreshToken) {
+      return null;
+    }
+    const refreshTokenHash = hashToken(refreshToken);
+    const session = await app.db.get(
+      `SELECT id, user_id, refresh_token_hash, csrf_token, expires_at
+         FROM user_sessions
+        WHERE refresh_token_hash = ?`,
+      [refreshTokenHash]
+    );
+    if (!session) {
+      return null;
+    }
+
+    if (new Date(session.expires_at).getTime() < Date.now()) {
+      await app.db.run('DELETE FROM user_sessions WHERE id = ?', [session.id]);
+      return null;
+    }
+
+    return session;
+  };
+
+  const requireCsrf = (request, reply, session) => {
+    const csrfHeader = request.headers['x-csrf-token'];
+    if (!csrfHeader || csrfHeader !== session?.csrf_token) {
+      reply.code(403).send({ error: 'Invalid CSRF token' });
+      return false;
+    }
+    return true;
+  };
+
+  const issueAccessToken = (user) =>
+    app.jwt.sign({ id: user.id, email: user.email }, { expiresIn: ACCESS_TOKEN_TTL });
+
+  app.get('/api/db-status', async () => {
+    const row = await app.db.get('SELECT 1 AS ok');
+    return {
+      ok: row?.ok === 1,
+      path: app.dbPath,
+    };
+  });
+
+  app.post('/api/auth/register', async (request, reply) => {
+    const { email, displayName, password } = request.body ?? {};
+    const validation = requireFields({ email, displayName, password }, [
+      'email',
+      'displayName',
+      'password',
+    ]);
+    if (!validation.ok) {
+      return reply.code(400).send({ error: 'Missing required fields', missing: validation.missing });
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 10);
+    try {
+      const result = await app.db.run(
+        'INSERT INTO users (email, display_name, password_hash) VALUES (?, ?, ?)',
+        [email, displayName, hashedPassword]
+      );
+      const playerRole = await app.db.get('SELECT id FROM roles WHERE name = ?', ['Player']);
+      if (playerRole?.id) {
+        await app.db.run('INSERT INTO user_roles (user_id, role_id) VALUES (?, ?)', [
+          result.lastID,
+          playerRole.id,
+        ]);
+      }
+      return reply.code(201).send({ id: result.lastID });
+    } catch (error) {
+      return reply.code(409).send({ error: 'User already exists' });
+    }
+  });
+
+  app.post('/api/auth/login', async (request, reply) => {
+    const { email, password } = request.body ?? {};
+    const validation = requireFields({ email, password }, ['email', 'password']);
+    if (!validation.ok) {
+      return reply.code(400).send({ error: 'Missing required fields', missing: validation.missing });
+    }
+
+    const user = await app.db.get(
+      'SELECT id, email, display_name, password_hash FROM users WHERE email = ?',
+      [email]
+    );
+    if (!user?.password_hash) {
+      return reply.code(401).send({ error: 'Invalid credentials' });
+    }
+
+    const isValid = await bcrypt.compare(password, user.password_hash);
+    if (!isValid) {
+      return reply.code(401).send({ error: 'Invalid credentials' });
+    }
+
+    const { refreshToken, csrfToken, expiresAt } = await createSession(user.id);
+    reply.setCookie(REFRESH_COOKIE, refreshToken, {
+      path: '/',
+      httpOnly: true,
+      sameSite: 'strict',
+      secure: process.env.NODE_ENV === 'production',
+      expires: new Date(expiresAt),
+    });
+
+    const accessToken = issueAccessToken(user);
+    return reply.send({
+      token: accessToken,
+      csrfToken,
+      user: { id: user.id, email: user.email, displayName: user.display_name },
+    });
+  });
+
+  app.get('/api/auth/session', async (request, reply) => {
+    const session = await getSessionFromRequest(request);
+    if (!session) {
+      return reply.code(401).send({ error: 'Unauthorized' });
+    }
+
+    const user = await app.db.get(
+      'SELECT id, email, display_name, created_at FROM users WHERE id = ?',
+      [session.user_id]
+    );
+    if (!user) {
+      return reply.code(401).send({ error: 'Unauthorized' });
+    }
+
+    const roles = await app.db.all(
+      `SELECT roles.name
+         FROM user_roles
+         JOIN roles ON roles.id = user_roles.role_id
+        WHERE user_roles.user_id = ?`,
+      [session.user_id]
+    );
+
+    const accessToken = issueAccessToken(user);
+    return reply.send({
+      token: accessToken,
+      csrfToken: session.csrf_token,
+      user: {
+        id: user.id,
+        email: user.email,
+        displayName: user.display_name,
+        created_at: user.created_at,
+        roles: roles.map((role) => role.name),
+      },
+    });
+  });
+
+  app.post('/api/auth/refresh', async (request, reply) => {
+    const session = await getSessionFromRequest(request);
+    if (!session) {
+      return reply.code(401).send({ error: 'Unauthorized' });
+    }
+    if (!requireCsrf(request, reply, session)) {
+      return;
+    }
+
+    const user = await app.db.get(
+      'SELECT id, email, display_name, created_at FROM users WHERE id = ?',
+      [session.user_id]
+    );
+    if (!user) {
+      return reply.code(401).send({ error: 'Unauthorized' });
+    }
+
+    const accessToken = issueAccessToken(user);
+    return reply.send({ token: accessToken });
+  });
+
+  app.post('/api/auth/logout', async (request, reply) => {
+    const session = await getSessionFromRequest(request);
+    if (!session) {
+      reply.clearCookie(REFRESH_COOKIE, { path: '/' });
+      return reply.send({ ok: true });
+    }
+    if (!requireCsrf(request, reply, session)) {
+      return;
+    }
+
+    await app.db.run('DELETE FROM user_sessions WHERE id = ?', [session.id]);
+    reply.clearCookie(REFRESH_COOKIE, { path: '/' });
+    return reply.send({ ok: true });
+  });
+
+  app.get('/api/me', { preHandler: [app.authenticate] }, async (request) => {
+    const user = await app.db.get(
+      'SELECT id, email, display_name, created_at FROM users WHERE id = ?',
+      [request.user.id]
+    );
+    if (!user) {
+      return { user: null };
+    }
+
+    const roles = await app.db.all(
+      `SELECT roles.name
+         FROM user_roles
+         JOIN roles ON roles.id = user_roles.role_id
+        WHERE user_roles.user_id = ?`,
+      [request.user.id]
+    );
+
+    return {
+      user: {
+        id: user.id,
+        email: user.email,
+        displayName: user.display_name,
+        created_at: user.created_at,
+        roles: roles.map((role) => role.name),
+      },
+    };
+  });
+
+  app.get('/api/users', { preHandler: [app.requireRoles(['Admin/Staff'])] }, async () => {
+    return app.db.all(
+      'SELECT id, email, display_name, created_at FROM users ORDER BY created_at DESC'
+    );
+  });
+
+  app.post(
+    '/api/users',
+    { preHandler: [app.requireRoles(['Admin/Staff'])] },
+    async (request, reply) => {
+    const { email, displayName } = request.body ?? {};
+    const validation = requireFields({ email, displayName }, ['email', 'displayName']);
+    if (!validation.ok) {
+      return reply.code(400).send({ error: 'Missing required fields', missing: validation.missing });
+    }
+
+    const result = await app.db.run(
+      'INSERT INTO users (email, display_name) VALUES (?, ?)',
+      [email, displayName]
+    );
+    return reply.code(201).send({ id: result.lastID });
+  });
+
+  app.get('/api/teams', async () => {
+    return app.db.all('SELECT id, name, created_at FROM teams ORDER BY created_at DESC');
+  });
+
+  app.post('/api/teams', async (request, reply) => {
+    const { name } = request.body ?? {};
+    const validation = requireFields({ name }, ['name']);
+    if (!validation.ok) {
+      return reply.code(400).send({ error: 'Missing required fields', missing: validation.missing });
+    }
+
+    const result = await app.db.run('INSERT INTO teams (name) VALUES (?)', [name]);
+    return reply.code(201).send({ id: result.lastID });
+  });
+
+  app.post(
+    '/api/teams/:teamId/members',
+    { preHandler: [app.requireRoles(['Captain', 'Organizer', 'Admin/Staff'])] },
+    async (request, reply) => {
+      const { teamId } = request.params ?? {};
+      const { userId, role } = request.body ?? {};
+      const validation = requireFields({ userId, role }, ['userId', 'role']);
+      if (!validation.ok) {
+        return reply
+          .code(400)
+          .send({ error: 'Missing required fields', missing: validation.missing });
+      }
+
+      await app.db.run(
+        'INSERT OR REPLACE INTO team_members (team_id, user_id, role) VALUES (?, ?, ?)',
+        [teamId, userId, role]
+      );
+      return reply.code(201).send({ teamId: Number(teamId), userId, role });
+    }
+  );
+
+  app.get('/api/roles', { preHandler: [app.requireRoles(['Admin/Staff', 'Organizer'])] }, async () => {
+    return app.db.all('SELECT id, name, created_at FROM roles ORDER BY name');
+  });
+
+  app.post(
+    '/api/roles',
+    { preHandler: [app.requireRoles(['Admin/Staff'])] },
+    async (request, reply) => {
+    const { name } = request.body ?? {};
+    const validation = requireFields({ name }, ['name']);
+    if (!validation.ok) {
+      return reply.code(400).send({ error: 'Missing required fields', missing: validation.missing });
+    }
+
+    const result = await app.db.run('INSERT INTO roles (name) VALUES (?)', [name]);
+    return reply.code(201).send({ id: result.lastID });
+  });
+
+  app.post(
+    '/api/users/:userId/roles',
+    { preHandler: [app.requireRoles(['Admin/Staff'])] },
+    async (request, reply) => {
+      const { userId } = request.params ?? {};
+      const { roleId } = request.body ?? {};
+      const validation = requireFields({ roleId }, ['roleId']);
+      if (!validation.ok) {
+        return reply.code(400).send({ error: 'Missing required fields', missing: validation.missing });
+      }
+
+      await app.db.run(
+        'INSERT OR REPLACE INTO user_roles (user_id, role_id) VALUES (?, ?)',
+        [userId, roleId]
+      );
+      return reply.code(201).send({ userId: Number(userId), roleId });
+    }
+  );
+
+  app.get('/api/tournaments', async () => {
+    return app.db.all(
+      'SELECT id, name, status, starts_at, ends_at, created_at FROM tournaments ORDER BY created_at DESC'
+    );
+  });
+
+  app.post(
+    '/api/tournaments',
+    { preHandler: [app.requireRoles(['Organizer', 'Admin/Staff'])] },
+    async (request, reply) => {
+      const { name, status, startsAt, endsAt } = request.body ?? {};
+      const validation = requireFields({ name }, ['name']);
+      if (!validation.ok) {
+        return reply
+          .code(400)
+          .send({ error: 'Missing required fields', missing: validation.missing });
+      }
+
+      const result = await app.db.run(
+        'INSERT INTO tournaments (name, status, starts_at, ends_at) VALUES (?, ?, ?, ?)',
+        [name, status ?? 'draft', startsAt ?? null, endsAt ?? null]
+      );
+      return reply.code(201).send({ id: result.lastID });
+    }
+  );
+
+  app.get('/api/events', async () => {
+    return app.db.all(
+      `SELECT events.id, events.tournament_id, events.name, events.game, events.format,
+              events.starts_at, events.created_at, tournaments.name AS tournament_name
+         FROM events
+         JOIN tournaments ON tournaments.id = events.tournament_id
+     ORDER BY events.created_at DESC`
+    );
+  });
+
+  app.post(
+    '/api/events',
+    { preHandler: [app.requireRoles(['Organizer', 'Admin/Staff'])] },
+    async (request, reply) => {
+      const { tournamentId, name, game, format, startsAt } = request.body ?? {};
+      const validation = requireFields(
+        { tournamentId, name, game, format },
+        ['tournamentId', 'name', 'game', 'format']
+      );
+      if (!validation.ok) {
+        return reply
+          .code(400)
+          .send({ error: 'Missing required fields', missing: validation.missing });
+      }
+
+      const result = await app.db.run(
+        'INSERT INTO events (tournament_id, name, game, format, starts_at) VALUES (?, ?, ?, ?, ?)',
+        [tournamentId, name, game, format, startsAt ?? null]
+      );
+      return reply.code(201).send({ id: result.lastID });
+    }
+  );
+
+  app.get('/api/schedule', async () => {
+    return app.db.all(
+      `SELECT matches.id, matches.event_id, matches.round, matches.scheduled_at, matches.status,
+              events.name AS event_name,
+              events.format,
+              tournaments.name AS tournament_name,
+              home_team.name AS home_team_name,
+              away_team.name AS away_team_name
+         FROM matches
+         JOIN events ON events.id = matches.event_id
+         JOIN tournaments ON tournaments.id = events.tournament_id
+         LEFT JOIN teams AS home_team ON home_team.id = matches.home_team_id
+         LEFT JOIN teams AS away_team ON away_team.id = matches.away_team_id
+     ORDER BY matches.scheduled_at IS NULL,
+              datetime(matches.scheduled_at) ASC,
+              matches.created_at ASC`
+    );
+  });
+
+  app.get('/api/matches', async () => {
+    return app.db.all(
+      `SELECT matches.id, matches.event_id, matches.round, matches.scheduled_at, matches.status,
+              matches.home_team_id, matches.away_team_id, matches.winner_team_id,
+              events.name AS event_name,
+              home_team.name AS home_team_name,
+              away_team.name AS away_team_name,
+              match_results.home_score,
+              match_results.away_score
+         FROM matches
+         JOIN events ON events.id = matches.event_id
+         LEFT JOIN teams AS home_team ON home_team.id = matches.home_team_id
+         LEFT JOIN teams AS away_team ON away_team.id = matches.away_team_id
+         LEFT JOIN match_results ON match_results.match_id = matches.id
+     ORDER BY matches.created_at DESC`
+    );
+  });
+
+  app.get('/api/matches/latest', async (request, reply) => {
+    const match = await app.db.get(
+      `SELECT matches.id, matches.event_id, matches.round, matches.scheduled_at, matches.status,
+              matches.home_team_id, matches.away_team_id, matches.winner_team_id,
+              events.name AS event_name,
+              home_team.name AS home_team_name,
+              away_team.name AS away_team_name,
+              match_results.home_score,
+              match_results.away_score
+         FROM matches
+         JOIN events ON events.id = matches.event_id
+         LEFT JOIN teams AS home_team ON home_team.id = matches.home_team_id
+         LEFT JOIN teams AS away_team ON away_team.id = matches.away_team_id
+         LEFT JOIN match_results ON match_results.match_id = matches.id
+     ORDER BY matches.created_at DESC
+        LIMIT 1`
+    );
+
+    if (!match) {
+      return reply.code(404).send({ error: 'No matches found' });
+    }
+
+    return match;
+  });
+
+  app.post(
+    '/api/matches',
+    { preHandler: [app.requireRoles(['Organizer', 'Admin/Staff'])] },
+    async (request, reply) => {
+      const { eventId, round, scheduledAt, status, homeTeamId, awayTeamId } = request.body ?? {};
+      const validation = requireFields({ eventId }, ['eventId']);
+      if (!validation.ok) {
+        return reply
+          .code(400)
+          .send({ error: 'Missing required fields', missing: validation.missing });
+      }
+
+      const result = await app.db.run(
+        `INSERT INTO matches (event_id, round, scheduled_at, status, home_team_id, away_team_id)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+        [
+          eventId,
+          round ?? 1,
+          scheduledAt ?? null,
+          status ?? 'scheduled',
+          homeTeamId ?? null,
+          awayTeamId ?? null,
+        ]
+      );
+      return reply.code(201).send({ id: result.lastID });
+    }
+  );
+
+  app.post(
+    '/api/matches/:matchId/result',
+    { preHandler: [app.requireRoles(['Organizer', 'Admin/Staff'])] },
+    async (request, reply) => {
+      const { matchId } = request.params ?? {};
+      const { homeScore, awayScore, notes, winnerTeamId } = request.body ?? {};
+      const validation = requireFields({ homeScore, awayScore }, ['homeScore', 'awayScore']);
+      if (!validation.ok) {
+        return reply
+          .code(400)
+          .send({ error: 'Missing required fields', missing: validation.missing });
+      }
+
+      await app.db.run(
+        `INSERT INTO match_results (match_id, home_score, away_score, notes)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT(match_id) DO UPDATE SET
+           home_score = excluded.home_score,
+           away_score = excluded.away_score,
+           notes = excluded.notes`,
+        [matchId, homeScore, awayScore, notes ?? null]
+      );
+
+      if (winnerTeamId) {
+        await app.db.run('UPDATE matches SET winner_team_id = ? WHERE id = ?', [
+          winnerTeamId,
+          matchId,
+        ]);
+      }
+
+      return reply.code(201).send({ matchId: Number(matchId) });
+    }
+  );
+
+  app.get('/api/standings', async () => {
+    return app.db.all(
+      `SELECT standings.id, standings.team_id, standings.wins, standings.losses,
+              standings.seed_points, standings.streak, standings.updated_at,
+              teams.name AS team_name
+         FROM standings
+         JOIN teams ON teams.id = standings.team_id
+     ORDER BY standings.seed_points DESC, standings.wins DESC`
+    );
+  });
+
+  app.post(
+    '/api/registrations',
+    { preHandler: [app.requireRoles(['Captain', 'Organizer', 'Admin/Staff'])] },
+    async (request, reply) => {
+      const { tournamentId, teamId, status } = request.body ?? {};
+      const validation = requireFields({ tournamentId, teamId }, ['tournamentId', 'teamId']);
+      if (!validation.ok) {
+        return reply
+          .code(400)
+          .send({ error: 'Missing required fields', missing: validation.missing });
+      }
+
+      const result = await app.db.run(
+        'INSERT INTO registrations (tournament_id, team_id, status) VALUES (?, ?, ?)',
+        [tournamentId, teamId, status ?? 'pending']
+      );
+      return reply.code(201).send({ id: result.lastID });
+    }
+  );
+
+  app.get('/api/brackets', async () => {
+    return app.db.all(
+      `SELECT brackets.id, brackets.event_id, brackets.name, brackets.bracket_type, brackets.created_at,
+              events.name AS event_name
+         FROM brackets
+         JOIN events ON events.id = brackets.event_id
+     ORDER BY brackets.created_at DESC`
+    );
+  });
+
+  app.post(
+    '/api/brackets',
+    { preHandler: [app.requireRoles(['Organizer', 'Admin/Staff'])] },
+    async (request, reply) => {
+      const { eventId, name, bracketType } = request.body ?? {};
+      const validation = requireFields({ eventId, name }, ['eventId', 'name']);
+      if (!validation.ok) {
+        return reply
+          .code(400)
+          .send({ error: 'Missing required fields', missing: validation.missing });
+      }
+
+      const result = await app.db.run(
+        'INSERT INTO brackets (event_id, name, bracket_type) VALUES (?, ?, ?)',
+        [eventId, name, bracketType ?? 'single_elimination']
+      );
+      return reply.code(201).send({ id: result.lastID });
+    }
+  );
+
+  app.get('/api/support/tickets', { preHandler: [app.requireRoles(['Admin/Staff'])] }, async () => {
+    return app.db.all(
+      `SELECT support_tickets.id, support_tickets.user_id, support_tickets.subject,
+              support_tickets.message, support_tickets.status, support_tickets.created_at,
+              users.email AS user_email
+         FROM support_tickets
+         LEFT JOIN users ON users.id = support_tickets.user_id
+     ORDER BY support_tickets.created_at DESC`
+    );
+  });
+
+  app.post('/api/support/tickets', { preHandler: [app.authenticate] }, async (request, reply) => {
+    const { subject, message } = request.body ?? {};
+    const validation = requireFields({ subject, message }, ['subject', 'message']);
+    if (!validation.ok) {
+      return reply
+        .code(400)
+        .send({ error: 'Missing required fields', missing: validation.missing });
+    }
+
+    const result = await app.db.run(
+      'INSERT INTO support_tickets (user_id, subject, message) VALUES (?, ?, ?)',
+      [request.user.id, subject, message]
+    );
+    return reply.code(201).send({ id: result.lastID });
+  });
+
+  app.get('/api/admin/actions', { preHandler: [app.requireRoles(['Admin/Staff'])] }, async () => {
+    return app.db.all(
+      `SELECT admin_actions.id, admin_actions.actor_user_id, admin_actions.action,
+              admin_actions.target_type, admin_actions.target_id, admin_actions.notes,
+              admin_actions.created_at, users.email AS actor_email
+         FROM admin_actions
+         LEFT JOIN users ON users.id = admin_actions.actor_user_id
+     ORDER BY admin_actions.created_at DESC`
+    );
+  });
+
+  app.post(
+    '/api/admin/actions',
+    { preHandler: [app.requireRoles(['Admin/Staff'])] },
+    async (request, reply) => {
+    const { action, targetType, targetId, notes } = request.body ?? {};
+    const validation = requireFields({ action }, ['action']);
+    if (!validation.ok) {
+      return reply
+        .code(400)
+        .send({ error: 'Missing required fields', missing: validation.missing });
+    }
+
+    const result = await app.db.run(
+      `INSERT INTO admin_actions (actor_user_id, action, target_type, target_id, notes)
+       VALUES (?, ?, ?, ?, ?)`,
+      [request.user.id, action, targetType ?? null, targetId ?? null, notes ?? null]
+    );
+    return reply.code(201).send({ id: result.lastID });
+  });
+
+  app.post('/api/tournament-signups', async (request, reply) => {
+    const {
+      type,
+      playerHandle,
+      email,
+      region,
+      rolePreference,
+      availability,
+      teamName,
+      captainName,
+      captainEmail,
+      teamSize,
+      timeSlot,
+      contactHandle,
+    } = request.body ?? {};
+
+    if (type === 'individual') {
+      const validation = requireFields(
+        { playerHandle, email, region, rolePreference, availability },
+        ['playerHandle', 'email', 'region', 'rolePreference', 'availability']
+      );
+      if (!validation.ok) {
+        return reply
+          .code(400)
+          .send({ error: 'Missing required fields', missing: validation.missing });
+      }
+    } else if (type === 'team') {
+      const validation = requireFields(
+        { teamName, captainName, captainEmail, teamSize, timeSlot, contactHandle },
+        ['teamName', 'captainName', 'captainEmail', 'teamSize', 'timeSlot', 'contactHandle']
+      );
+      if (!validation.ok) {
+        return reply
+          .code(400)
+          .send({ error: 'Missing required fields', missing: validation.missing });
+      }
+    } else {
+      return reply.code(400).send({ error: 'Invalid signup type' });
+    }
+
+    const result = await app.db.run(
+      `INSERT INTO tournament_signups (
+         signup_type,
+         player_handle,
+         email,
+         region,
+         role_preference,
+         availability,
+         team_name,
+         captain_name,
+         captain_email,
+         team_size,
+         time_slot,
+         contact_handle
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        type,
+        playerHandle ?? null,
+        email ?? null,
+        region ?? null,
+        rolePreference ?? null,
+        availability ?? null,
+        teamName ?? null,
+        captainName ?? null,
+        captainEmail ?? null,
+        teamSize ?? null,
+        timeSlot ?? null,
+        contactHandle ?? null,
+      ]
+    );
+
+    return reply.code(201).send({ id: result.lastID });
+  });
+};

--- a/login.html
+++ b/login.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Arcadia Clash is a competitive tournament hub for managing brackets, teams, and live matches." />
+    <meta property="og:title" content="Arcadia Clash - Tournament Hub" />
+    <meta property="og:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://arcadiaclash.gg/" />
+    <meta property="og:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Arcadia Clash - Tournament Hub" />
+    <meta name="twitter:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta name="twitter:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <title>Arcadia Clash - Sign In</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ARCADIA-0001"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-ARCADIA-0001");
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav">
+        <a class="logo" href="index.html">
+          <span class="logo-mark">AC</span>
+          <span class="logo-text">Arcadia Clash</span>
+        </a>
+        <div class="nav-links">
+          <a href="index.html#features">Features</a>
+          <a href="index.html#brackets">Brackets</a>
+          <a href="index.html#schedule">Schedule</a>
+          <a href="index.html#community">Community</a>
+          <a href="signup.html">Tournament Sign Up</a>
+          <a href="user-signup.html">User Sign Up</a>
+          <a href="schedule.html">Schedule List</a>
+          <a href="faq.html">FAQ</a>
+          <a href="team-management.html">Team Management</a>
+          <a href="player-dashboard.html">Player Dashboard</a>
+          <a href="player-profile.html">Player Profile</a>
+          <a href="team-profile.html">Team Profile</a>
+          <a href="match-center.html">Match Center</a>
+          <a href="event-detail.html">Event Detail</a>
+          <a href="tickets.html">Tickets</a>
+          <a href="support.html">Support</a>
+          <a href="rules.html">Rules</a>
+          <a href="standings.html">Standings</a>
+          <a href="admin-console.html">Admin Console</a>
+          <a href="seeding.html">Seeding</a>
+        </div>
+        <div class="auth-status" data-auth-status>
+          <a class="btn ghost" href="login.html" data-auth-signin>Sign In</a>
+          <div class="auth-user is-hidden" data-auth-user></div>
+          <button class="btn ghost is-hidden" type="button" data-auth-logout>Sign Out</button>
+        </div>
+      </nav>
+    </header>
+
+    <main class="auth">
+      <section class="auth-hero">
+        <p class="tag">Arcadia Clash Account</p>
+        <h1>Sign in to manage your tournament journey.</h1>
+        <p class="subhead">
+          Access team tools, manage brackets, and unlock organizer actions with your Arcadia ID.
+        </p>
+      </section>
+
+      <section class="auth-card">
+        <h2>Sign in</h2>
+        <p class="form-note">
+          Enter your email and password to receive a session token for admin and team tools.
+        </p>
+        <form id="login-form">
+          <label>
+            Email address
+            <input type="email" name="email" placeholder="you@email.com" required />
+          </label>
+          <label>
+            Password
+            <input type="password" name="password" placeholder="Your password" required />
+          </label>
+          <button class="btn primary full" type="submit">Sign in</button>
+          <p id="login-status" class="helper-text" role="status"></p>
+        </form>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div>
+        <h3>Need an Arcadia ID?</h3>
+        <p>Create an account to register teams and receive tournament alerts.</p>
+      </div>
+      <a class="btn secondary" href="user-signup.html">Create account</a>
+    </footer>
+
+    <script src="auth.js"></script>
+    <script src="login.js"></script>
+  </body>
+</html>

--- a/login.js
+++ b/login.js
@@ -1,0 +1,54 @@
+const form = document.querySelector('#login-form');
+const statusEl = document.querySelector('#login-status');
+
+const setStatus = (message, type = 'info') => {
+  if (!statusEl) {
+    return;
+  }
+  statusEl.textContent = message;
+  if (type === 'error' || type === 'success') {
+    statusEl.dataset.status = type;
+  } else {
+    statusEl.removeAttribute('data-status');
+  }
+};
+
+if (form) {
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+
+    const formData = new FormData(form);
+    const email = formData.get('email')?.toString().trim();
+    const password = formData.get('password')?.toString();
+
+    if (!email || !password) {
+      setStatus('Enter your email and password to sign in.', 'error');
+      return;
+    }
+
+    const response = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+      credentials: 'include',
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      setStatus(error?.error ?? 'Unable to sign in.', 'error');
+      return;
+    }
+
+    const data = await response.json();
+    if (data?.token && window.ArcadiaAuth) {
+      window.ArcadiaAuth.setSession(data);
+    }
+
+    setStatus('Signed in. Redirecting now...', 'success');
+    const params = new URLSearchParams(window.location.search);
+    const returnTo = params.get('returnTo');
+    const safeReturnTo =
+      returnTo && !returnTo.includes('://') && !returnTo.startsWith('//') ? returnTo : 'index.html';
+    window.location.href = safeReturnTo || 'index.html';
+  });
+}

--- a/match-center.html
+++ b/match-center.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Arcadia Clash is a competitive tournament hub for managing brackets, teams, and live matches." />
+    <meta property="og:title" content="Arcadia Clash - Tournament Hub" />
+    <meta property="og:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://arcadiaclash.gg/" />
+    <meta property="og:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Arcadia Clash - Tournament Hub" />
+    <meta name="twitter:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta name="twitter:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <title>Arcadia Clash - Match Center</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ARCADIA-0001"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-ARCADIA-0001");
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav">
+        <a class="logo" href="index.html">
+          <span class="logo-mark">AC</span>
+          <span class="logo-text">Arcadia Clash</span>
+        </a>
+        <div class="nav-links">
+          <a href="index.html#features">Features</a>
+          <a href="index.html#brackets">Brackets</a>
+          <a href="index.html#schedule">Schedule</a>
+          <a href="index.html#community">Community</a>
+          <a href="signup.html">Tournament Sign Up</a>
+          <a href="user-signup.html">User Sign Up</a>
+          <a href="schedule.html">Schedule List</a>
+          <a href="team-management.html">Team Management</a>
+          <a href="player-dashboard.html">Player Dashboard</a>
+          <a href="match-center.html" class="active">Match Center</a>
+          <a href="player-profile.html">Player Profile</a>
+          <a href="team-profile.html">Team Profile</a>
+          <a href="event-detail.html">Event Detail</a>
+          <a href="tickets.html">Tickets</a>
+          <a href="support.html">Support</a>
+          <a href="rules.html">Rules</a>
+          <a href="standings.html">Standings</a>
+          <a href="admin-console.html">Admin Console</a>
+          <a href="seeding.html">Seeding</a>
+          <a href="faq.html">FAQ</a>
+        </div>
+        <div class="auth-status" data-auth-status>
+          <a class="btn ghost" href="login.html" data-auth-signin>Sign In</a>
+          <div class="auth-user is-hidden" data-auth-user></div>
+          <button class="btn ghost is-hidden" type="button" data-auth-logout>Sign Out</button>
+        </div>
+      </nav>
+    </header>
+
+    <main class="match-center">
+      <section class="match-hero">
+        <div>
+          <p class="tag" id="match-tag">Live Match • Best of 5</p>
+          <h1 id="match-title">Crimson Circuit vs Nebula Wolves</h1>
+          <p class="subhead" id="match-meta">
+            Grand Arena · Round 3 · 24,000 viewers. Catch the stream, stats, and live timeline in one
+            place.
+          </p>
+        </div>
+        <div class="match-actions">
+          <button class="btn primary">Watch live stream</button>
+          <button class="btn secondary">Follow match</button>
+        </div>
+      </section>
+
+      <section class="match-grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Scoreboard</h2>
+            <button class="btn ghost">View recap</button>
+          </div>
+          <p id="match-data-status" class="helper-text" role="status"></p>
+          <div class="scoreboard">
+            <div class="team-score">
+              <div class="team-info">
+                <div class="avatar">CC</div>
+                <div>
+                  <h3 id="match-home-name">Crimson Circuit</h3>
+                  <p id="match-home-record">#1 Seed · 3-1</p>
+                </div>
+              </div>
+              <span class="score" id="match-home-score">2</span>
+            </div>
+            <div class="team-score">
+              <div class="team-info">
+                <div class="avatar">NW</div>
+                <div>
+                  <h3 id="match-away-name">Nebula Wolves</h3>
+                  <p id="match-away-record">#4 Seed · 2-2</p>
+                </div>
+              </div>
+              <span class="score" id="match-away-score">1</span>
+            </div>
+          </div>
+          <div class="map-list">
+            <div>
+              <h4>Map 1 · Splat Zones</h4>
+              <p>Crimson Circuit wins 204 - 178</p>
+            </div>
+            <div>
+              <h4>Map 2 · Tower Control</h4>
+              <p>Nebula Wolves wins 100 - 78</p>
+            </div>
+            <div>
+              <h4>Map 3 · Rainmaker</h4>
+              <p>Crimson Circuit wins 83 - 54</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Live stats</h2>
+            <button class="btn ghost">Toggle view</button>
+          </div>
+          <div class="stat-grid">
+            <div>
+              <h3>62%</h3>
+              <p>Paint control</p>
+            </div>
+            <div>
+              <h3>18</h3>
+              <p>Team wipes</p>
+            </div>
+            <div>
+              <h3>43</h3>
+              <p>Specials used</p>
+            </div>
+            <div>
+              <h3>2:14</h3>
+              <p>Avg. push time</p>
+            </div>
+          </div>
+          <div class="timeline">
+            <h3>Live timeline</h3>
+            <ul>
+              <li>2:14 PM · Crimson Circuit captures checkpoint</li>
+              <li>2:10 PM · Nebula Wolves wipe mid control</li>
+              <li>2:05 PM · InkNova lands triple splat</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section class="match-grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Player highlights</h2>
+            <button class="btn ghost">View all clips</button>
+          </div>
+          <div class="highlight-list">
+            <div class="highlight-card">
+              <h3>InkNova</h3>
+              <p>Rainmaker steal · 12k views</p>
+              <button class="btn secondary">Watch</button>
+            </div>
+            <div class="highlight-card">
+              <h3>Seavolt</h3>
+              <p>Zone hold streak · 8k views</p>
+              <button class="btn secondary">Watch</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Stream chat</h2>
+            <button class="btn ghost">Moderate</button>
+          </div>
+          <div class="chat-box">
+            <p><strong>HydraFan:</strong> That checkpoint play was insane!</p>
+            <p><strong>InkGear:</strong> Nebula Wolves still have time to clutch.</p>
+            <p><strong>ClipsBot:</strong> New highlight clipped by @InkNova</p>
+          </div>
+          <button class="btn primary">Open chat</button>
+        </div>
+      </section>
+
+      <section class="match-grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Report match result</h2>
+            <span class="pill">Organizer access</span>
+          </div>
+          <form id="match-result-form" class="stacked-form">
+            <p class="helper-text">Sign in with organizer access to submit match results.</p>
+            <label class="field">
+              <span>Match ID</span>
+              <input type="number" name="matchId" placeholder="10" required />
+            </label>
+            <label class="field">
+              <span>Home score</span>
+              <input type="number" name="homeScore" placeholder="3" required />
+            </label>
+            <label class="field">
+              <span>Away score</span>
+              <input type="number" name="awayScore" placeholder="1" required />
+            </label>
+            <label class="field">
+              <span>Winner team ID</span>
+              <input type="number" name="winnerTeamId" placeholder="4" />
+            </label>
+            <label class="field">
+              <span>Notes</span>
+              <textarea name="notes" rows="3" placeholder="Overtime decision"></textarea>
+            </label>
+            <button class="btn primary" type="submit">Submit result</button>
+            <p id="match-result-status" class="helper-text" role="status"></p>
+          </form>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div>
+        <h3>Stay tuned for the next match</h3>
+        <p>Enable match alerts to get notified when the next map goes live.</p>
+      </div>
+      <button class="btn primary">Enable match alerts</button>
+    </footer>
+    <script src="auth.js"></script>
+    <script src="match-center.js"></script>
+  </body>
+</html>

--- a/match-center.js
+++ b/match-center.js
@@ -1,0 +1,133 @@
+const resultForm = document.querySelector('#match-result-form');
+const resultStatus = document.querySelector('#match-result-status');
+const authClient = window.ArcadiaAuth;
+const matchTitle = document.querySelector('#match-title');
+const matchMeta = document.querySelector('#match-meta');
+const matchTag = document.querySelector('#match-tag');
+const matchStatus = document.querySelector('#match-data-status');
+const homeName = document.querySelector('#match-home-name');
+const awayName = document.querySelector('#match-away-name');
+const homeScore = document.querySelector('#match-home-score');
+const awayScore = document.querySelector('#match-away-score');
+
+const setStatus = (element, message, type = 'info') => {
+  if (!element) {
+    return;
+  }
+  element.textContent = message;
+  if (type === 'error' || type === 'success') {
+    element.dataset.status = type;
+  } else {
+    element.removeAttribute('data-status');
+  }
+};
+
+const setMatchStatus = (message, type = 'info') => setStatus(matchStatus, message, type);
+
+const POLL_INTERVAL_MS = 15000;
+let pollHandle;
+
+const loadLatestMatch = async () => {
+  if (!matchTitle || !matchMeta || !matchStatus) {
+    return;
+  }
+
+  const response = await fetch('/api/matches/latest');
+  if (!response.ok) {
+    setMatchStatus('Live match data unavailable.', 'error');
+    return;
+  }
+
+  const match = await response.json();
+  const homeTeam = match.home_team_name ?? 'TBD';
+  const awayTeam = match.away_team_name ?? 'TBD';
+
+  if (matchTag) {
+    matchTag.textContent = `${match.status ?? 'Scheduled'} • Round ${match.round ?? 1}`;
+  }
+  matchTitle.textContent = `${homeTeam} vs ${awayTeam}`;
+  matchMeta.textContent = `${match.event_name ?? 'Main Event'} · Round ${match.round ?? 1}`;
+
+  if (homeName) {
+    homeName.textContent = homeTeam;
+  }
+  if (awayName) {
+    awayName.textContent = awayTeam;
+  }
+  if (homeScore) {
+    homeScore.textContent = match.home_score ?? 0;
+  }
+  if (awayScore) {
+    awayScore.textContent = match.away_score ?? 0;
+  }
+
+  setMatchStatus('Live match data synced.', 'success');
+};
+
+const startPolling = () => {
+  if (pollHandle) {
+    return;
+  }
+  pollHandle = window.setInterval(() => {
+    loadLatestMatch();
+  }, POLL_INTERVAL_MS);
+};
+
+const stopPolling = () => {
+  if (!pollHandle) {
+    return;
+  }
+  window.clearInterval(pollHandle);
+  pollHandle = null;
+};
+
+if (resultForm) {
+  resultForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!authClient?.getAccessToken()) {
+      setStatus(resultStatus, 'Sign in to submit a match result.', 'error');
+      return;
+    }
+
+    const formData = new FormData(resultForm);
+    const matchId = formData.get('matchId')?.toString().trim();
+    const homeScore = formData.get('homeScore')?.toString().trim();
+    const awayScore = formData.get('awayScore')?.toString().trim();
+    const winnerTeamId = formData.get('winnerTeamId')?.toString().trim();
+    const notes = formData.get('notes')?.toString().trim();
+
+    const response = await authClient.authenticatedFetch(`/api/matches/${matchId}/result`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        homeScore: Number(homeScore),
+        awayScore: Number(awayScore),
+        winnerTeamId: winnerTeamId ? Number(winnerTeamId) : null,
+        notes: notes || null,
+      }),
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      setStatus(resultStatus, error?.error ?? 'Unable to submit match result.', 'error');
+      return;
+    }
+
+    resultForm.reset();
+    setStatus(resultStatus, 'Match result submitted.', 'success');
+  });
+}
+
+loadLatestMatch();
+startPolling();
+
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden) {
+    stopPolling();
+  } else {
+    loadLatestMatch();
+    startPolling();
+  }
+});

--- a/player-dashboard.html
+++ b/player-dashboard.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Arcadia Clash is a competitive tournament hub for managing brackets, teams, and live matches." />
+    <meta property="og:title" content="Arcadia Clash - Tournament Hub" />
+    <meta property="og:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://arcadiaclash.gg/" />
+    <meta property="og:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Arcadia Clash - Tournament Hub" />
+    <meta name="twitter:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta name="twitter:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <title>Arcadia Clash - Player Dashboard</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ARCADIA-0001"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-ARCADIA-0001");
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav">
+        <a class="logo" href="index.html">
+          <span class="logo-mark">AC</span>
+          <span class="logo-text">Arcadia Clash</span>
+        </a>
+        <div class="nav-links">
+          <a href="index.html#features">Features</a>
+          <a href="index.html#brackets">Brackets</a>
+          <a href="index.html#schedule">Schedule</a>
+          <a href="index.html#community">Community</a>
+          <a href="signup.html">Tournament Sign Up</a>
+          <a href="user-signup.html">User Sign Up</a>
+          <a href="schedule.html">Schedule List</a>
+          <a href="team-management.html">Team Management</a>
+          <a href="player-dashboard.html" class="active">Player Dashboard</a>
+          <a href="player-profile.html">Player Profile</a>
+          <a href="team-profile.html">Team Profile</a>
+          <a href="match-center.html">Match Center</a>
+          <a href="event-detail.html">Event Detail</a>
+          <a href="tickets.html">Tickets</a>
+          <a href="support.html">Support</a>
+          <a href="rules.html">Rules</a>
+          <a href="standings.html">Standings</a>
+          <a href="admin-console.html">Admin Console</a>
+          <a href="seeding.html">Seeding</a>
+          <a href="faq.html">FAQ</a>
+        </div>
+        <div class="auth-status" data-auth-status>
+          <a class="btn ghost" href="login.html" data-auth-signin>Sign In</a>
+          <div class="auth-user is-hidden" data-auth-user></div>
+          <button class="btn ghost is-hidden" type="button" data-auth-logout>Sign Out</button>
+        </div>
+      </nav>
+    </header>
+
+    <main class="player-dashboard">
+      <section class="dashboard-hero">
+        <div>
+          <p class="tag">Arcadia ID • Player Hub</p>
+          <h1>Welcome back, InkNova.</h1>
+          <p class="subhead">
+            Track your performance, upcoming matches, and team invites in one personalized
+            dashboard.
+          </p>
+        </div>
+        <div class="dashboard-actions">
+          <button class="btn primary">Edit profile</button>
+          <button class="btn secondary">Share stats</button>
+        </div>
+      </section>
+
+      <section class="dashboard-grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Season stats</h2>
+            <button class="btn ghost">View full stats</button>
+          </div>
+          <div class="stat-grid">
+            <div>
+              <h3>18</h3>
+              <p>Matches played</p>
+            </div>
+            <div>
+              <h3>72%</h3>
+              <p>Win rate</p>
+            </div>
+            <div>
+              <h3>2.8</h3>
+              <p>K/D ratio</p>
+            </div>
+            <div>
+              <h3>+214</h3>
+              <p>Ink differential</p>
+            </div>
+          </div>
+          <div class="progress-card">
+            <div>
+              <h3>Rank progress</h3>
+              <p>Diamond II · 140 / 200 points</p>
+            </div>
+            <div class="progress-bar">
+              <span style="width: 70%"></span>
+            </div>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Upcoming matches</h2>
+            <button class="btn ghost">Open calendar</button>
+          </div>
+          <div class="match-list">
+            <div>
+              <h3>Apr 6 · Scrim vs Neon Nautilus</h3>
+              <p>7:00 PM PT · Best of 3</p>
+            </div>
+            <div>
+              <h3>Apr 9 · Qualifier Round 2</h3>
+              <p>8:30 PM PT · Stream B</p>
+            </div>
+            <div>
+              <h3>Apr 12 · Regional Playoffs</h3>
+              <p>6:00 PM PT · Stream A</p>
+            </div>
+          </div>
+          <button class="btn secondary">RSVP to match</button>
+        </div>
+      </section>
+
+      <section class="dashboard-grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Team invites</h2>
+            <button class="btn ghost">Manage invites</button>
+          </div>
+          <div class="invite-list">
+            <div class="invite-card">
+              <div>
+                <h3>Lagoon Legends</h3>
+                <p>Seeking flex player · 4 scrims/week</p>
+              </div>
+              <div class="invite-actions">
+                <button class="btn secondary">View</button>
+                <button class="btn ghost">Decline</button>
+              </div>
+            </div>
+            <div class="invite-card">
+              <div>
+                <h3>Solar Splatter</h3>
+                <p>Backup anchor · LAN available</p>
+              </div>
+              <div class="invite-actions">
+                <button class="btn secondary">View</button>
+                <button class="btn ghost">Decline</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Highlights</h2>
+            <button class="btn ghost">Upload clip</button>
+          </div>
+          <div class="highlight-card">
+            <h3>Top clip of the week</h3>
+            <p>Rainmaker triple splat · 24k views</p>
+            <button class="btn primary">Watch clip</button>
+          </div>
+          <div class="highlight-grid">
+            <div>
+              <h4>Recent</h4>
+              <p>5 new clips</p>
+            </div>
+            <div>
+              <h4>Achievements</h4>
+              <p>3 badges unlocked</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div>
+        <h3>Stay match-ready</h3>
+        <p>Enable alerts for roster changes and match reminders.</p>
+      </div>
+      <button class="btn primary">Enable alerts</button>
+    </footer>
+    <script src="auth.js"></script>
+  </body>
+</html>

--- a/player-profile.html
+++ b/player-profile.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Arcadia Clash is a competitive tournament hub for managing brackets, teams, and live matches." />
+    <meta property="og:title" content="Arcadia Clash - Tournament Hub" />
+    <meta property="og:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://arcadiaclash.gg/" />
+    <meta property="og:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Arcadia Clash - Tournament Hub" />
+    <meta name="twitter:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta name="twitter:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <title>Arcadia Clash - Player Profile</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ARCADIA-0001"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-ARCADIA-0001");
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav">
+        <a class="logo" href="index.html">
+          <span class="logo-mark">AC</span>
+          <span class="logo-text">Arcadia Clash</span>
+        </a>
+        <div class="nav-links">
+          <a href="index.html#features">Features</a>
+          <a href="index.html#brackets">Brackets</a>
+          <a href="index.html#schedule">Schedule</a>
+          <a href="index.html#community">Community</a>
+          <a href="signup.html">Tournament Sign Up</a>
+          <a href="user-signup.html">User Sign Up</a>
+          <a href="schedule.html">Schedule List</a>
+          <a href="team-management.html">Team Management</a>
+          <a href="player-dashboard.html">Player Dashboard</a>
+          <a href="player-profile.html" class="active">Player Profile</a>
+          <a href="team-profile.html">Team Profile</a>
+          <a href="match-center.html">Match Center</a>
+          <a href="event-detail.html">Event Detail</a>
+          <a href="tickets.html">Tickets</a>
+          <a href="support.html">Support</a>
+          <a href="rules.html">Rules</a>
+          <a href="standings.html">Standings</a>
+          <a href="admin-console.html">Admin Console</a>
+          <a href="seeding.html">Seeding</a>
+          <a href="faq.html">FAQ</a>
+        </div>
+        <div class="auth-status" data-auth-status>
+          <a class="btn ghost" href="login.html" data-auth-signin>Sign In</a>
+          <div class="auth-user is-hidden" data-auth-user></div>
+          <button class="btn ghost is-hidden" type="button" data-auth-logout>Sign Out</button>
+        </div>
+      </nav>
+    </header>
+
+    <main class="profile">
+      <section class="profile-hero">
+        <div class="profile-card">
+          <div class="profile-avatar">IN</div>
+          <div>
+            <p class="tag">Arcadia ID</p>
+            <h1>InkNova</h1>
+            <p class="subhead">Flex player · Splatoon 3 · North America</p>
+          </div>
+          <div class="profile-actions">
+            <button class="btn primary">Follow player</button>
+            <button class="btn secondary">Invite to team</button>
+          </div>
+        </div>
+        <div class="profile-stats">
+          <div>
+            <h3>72%</h3>
+            <p>Win rate</p>
+          </div>
+          <div>
+            <h3>18</h3>
+            <p>Matches</p>
+          </div>
+          <div>
+            <h3>2.8</h3>
+            <p>K/D ratio</p>
+          </div>
+          <div>
+            <h3>#12</h3>
+            <p>Player rank</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="profile-grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Recent match history</h2>
+            <button class="btn ghost">Full history</button>
+          </div>
+          <div class="history-list">
+            <div>
+              <h3>Win · vs Solar Splatter</h3>
+              <p>Rainmaker · 83 - 54 · 2 days ago</p>
+            </div>
+            <div>
+              <h3>Loss · vs Lagoon Legends</h3>
+              <p>Tower Control · 78 - 100 · 4 days ago</p>
+            </div>
+            <div>
+              <h3>Win · vs Neon Nautilus</h3>
+              <p>Splat Zones · 204 - 178 · 1 week ago</p>
+            </div>
+          </div>
+          <button class="btn secondary">Share match history</button>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Signature loadout</h2>
+            <button class="btn ghost">View gear</button>
+          </div>
+          <div class="loadout-grid">
+            <div>
+              <h3>Weapon</h3>
+              <p>Splattershot Pro</p>
+            </div>
+            <div>
+              <h3>Special</h3>
+              <p>Crab Tank</p>
+            </div>
+            <div>
+              <h3>Sub</h3>
+              <p>Angle Shooter</p>
+            </div>
+            <div>
+              <h3>Playstyle</h3>
+              <p>Map control & picks</p>
+            </div>
+          </div>
+          <div class="highlight-card">
+            <h3>Top clip</h3>
+            <p>Zone hold streak · 24k views</p>
+            <button class="btn secondary">Watch clip</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="profile-grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Team history</h2>
+            <button class="btn ghost">View teams</button>
+          </div>
+          <div class="history-list">
+            <div>
+              <h3>Crimson Circuit</h3>
+              <p>Starter · 2024 Season · Finals appearance</p>
+            </div>
+            <div>
+              <h3>Neon Nautilus</h3>
+              <p>Substitute · 2023 Season · Top 8</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Player highlights</h2>
+            <button class="btn ghost">Upload clip</button>
+          </div>
+          <div class="highlight-list">
+            <div class="highlight-card">
+              <h3>Rainmaker steal</h3>
+              <p>12k views · 1 week ago</p>
+              <button class="btn secondary">Watch</button>
+            </div>
+            <div class="highlight-card">
+              <h3>Triple splat</h3>
+              <p>8k views · 2 weeks ago</p>
+              <button class="btn secondary">Watch</button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div>
+        <h3>Looking for a team?</h3>
+        <p>Open your availability and let captains know you are ready.</p>
+      </div>
+      <button class="btn primary">Open to invites</button>
+    </footer>
+    <script src="auth.js"></script>
+  </body>
+</html>

--- a/rules.html
+++ b/rules.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Arcadia Clash is a competitive tournament hub for managing brackets, teams, and live matches." />
+    <meta property="og:title" content="Arcadia Clash - Tournament Hub" />
+    <meta property="og:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://arcadiaclash.gg/" />
+    <meta property="og:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Arcadia Clash - Tournament Hub" />
+    <meta name="twitter:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta name="twitter:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <title>Arcadia Clash - Rules & Code of Conduct</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ARCADIA-0001"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-ARCADIA-0001");
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav">
+        <a class="logo" href="index.html">
+          <span class="logo-mark">AC</span>
+          <span class="logo-text">Arcadia Clash</span>
+        </a>
+        <div class="nav-links">
+          <a href="index.html#features">Features</a>
+          <a href="index.html#brackets">Brackets</a>
+          <a href="index.html#schedule">Schedule</a>
+          <a href="index.html#community">Community</a>
+          <a href="signup.html">Tournament Sign Up</a>
+          <a href="user-signup.html">User Sign Up</a>
+          <a href="schedule.html">Schedule List</a>
+          <a href="team-management.html">Team Management</a>
+          <a href="player-dashboard.html">Player Dashboard</a>
+          <a href="match-center.html">Match Center</a>
+          <a href="player-profile.html">Player Profile</a>
+          <a href="team-profile.html">Team Profile</a>
+          <a href="event-detail.html">Event Detail</a>
+          <a href="tickets.html">Tickets</a>
+          <a href="support.html">Support</a>
+          <a href="rules.html" class="active">Rules</a>
+          <a href="standings.html">Standings</a>
+          <a href="admin-console.html">Admin Console</a>
+          <a href="seeding.html">Seeding</a>
+          <a href="faq.html">FAQ</a>
+        </div>
+        <div class="auth-status" data-auth-status>
+          <a class="btn ghost" href="login.html" data-auth-signin>Sign In</a>
+          <div class="auth-user is-hidden" data-auth-user></div>
+          <button class="btn ghost is-hidden" type="button" data-auth-logout>Sign Out</button>
+        </div>
+      </nav>
+    </header>
+
+    <main class="rules">
+      <section class="rules-hero">
+        <div>
+          <p class="tag">Splatoon 3 • Tournament Policy</p>
+          <h1>Rules & Code of Conduct</h1>
+          <p class="subhead">
+            These guidelines keep Arcadia Clash competitive, fair, and respectful. Review before
+            registering or joining a team.
+          </p>
+        </div>
+        <div class="rules-actions">
+          <button class="btn secondary">Download PDF</button>
+          <button class="btn ghost">Report an issue</button>
+        </div>
+      </section>
+
+      <section class="rules-grid">
+        <article class="rules-card">
+          <h2>Eligibility</h2>
+          <ul>
+            <li>Players must be 16+ or have guardian consent.</li>
+            <li>Regional eligibility is based on residency.</li>
+            <li>Smurfing or account sharing is prohibited.</li>
+          </ul>
+        </article>
+        <article class="rules-card">
+          <h2>Roster rules</h2>
+          <ul>
+            <li>Teams field 4 starters and up to 2 substitutes.</li>
+            <li>Roster lock occurs 48 hours before the event.</li>
+            <li>Emergency swaps require admin approval.</li>
+          </ul>
+        </article>
+        <article class="rules-card">
+          <h2>Match operations</h2>
+          <ul>
+            <li>Check-in opens 60 minutes before match time.</li>
+            <li>Default wins occur after 15 minutes of no-show.</li>
+            <li>Disconnections must be reported within 5 minutes.</li>
+          </ul>
+        </article>
+        <article class="rules-card">
+          <h2>Streaming & media</h2>
+          <ul>
+            <li>Official streams have broadcast priority.</li>
+            <li>Players may stream with a 2-minute delay.</li>
+            <li>Clips and highlights must credit Arcadia Clash.</li>
+          </ul>
+        </article>
+        <article class="rules-card">
+          <h2>Code of conduct</h2>
+          <ul>
+            <li>Respect opponents, staff, and spectators.</li>
+            <li>No hate speech, harassment, or griefing.</li>
+            <li>Unsportsmanlike conduct results in penalties.</li>
+          </ul>
+        </article>
+        <article class="rules-card">
+          <h2>Penalties</h2>
+          <ul>
+            <li>Warnings for minor violations.</li>
+            <li>Match forfeits for repeated offenses.</li>
+            <li>Season bans for severe misconduct.</li>
+          </ul>
+        </article>
+      </section>
+
+      <section class="rules-callout">
+        <div>
+          <h2>Need clarification?</h2>
+          <p>Contact tournament staff or submit a ticket for review.</p>
+        </div>
+        <button class="btn primary">Contact admins</button>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div>
+        <h3>Play fair, play fierce</h3>
+        <p>Thanks for helping us keep Arcadia Clash competitive and welcoming.</p>
+      </div>
+      <button class="btn secondary">Read full policy</button>
+    </footer>
+    <script src="auth.js"></script>
+  </body>
+</html>

--- a/schedule.html
+++ b/schedule.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Arcadia Clash is a competitive tournament hub for managing brackets, teams, and live matches." />
+    <meta property="og:title" content="Arcadia Clash - Tournament Hub" />
+    <meta property="og:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://arcadiaclash.gg/" />
+    <meta property="og:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Arcadia Clash - Tournament Hub" />
+    <meta name="twitter:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta name="twitter:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <title>Arcadia Clash - Schedule List</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ARCADIA-0001"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-ARCADIA-0001");
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav">
+        <a class="logo" href="index.html">
+          <span class="logo-mark">AC</span>
+          <span class="logo-text">Arcadia Clash</span>
+        </a>
+        <div class="nav-links">
+          <a href="index.html#features">Features</a>
+          <a href="index.html#brackets">Brackets</a>
+          <a href="index.html#schedule">Schedule</a>
+          <a href="index.html#community">Community</a>
+          <a href="signup.html">Tournament Sign Up</a>
+          <a href="user-signup.html">User Sign Up</a>
+          <a href="schedule.html" class="active">Schedule List</a>
+          <a href="seeding.html">Seeding</a>
+          <a href="faq.html">FAQ</a>
+          <a href="team-management.html">Team Management</a>
+          <a href="player-dashboard.html">Player Dashboard</a>
+          <a href="player-profile.html">Player Profile</a>
+          <a href="team-profile.html">Team Profile</a>
+          <a href="match-center.html">Match Center</a>
+          <a href="event-detail.html">Event Detail</a>
+          <a href="tickets.html">Tickets</a>
+          <a href="support.html">Support</a>
+          <a href="rules.html">Rules</a>
+          <a href="standings.html">Standings</a>
+          <a href="admin-console.html">Admin Console</a>
+        </div>
+        <div class="auth-status" data-auth-status>
+          <a class="btn ghost" href="login.html" data-auth-signin>Sign In</a>
+          <div class="auth-user is-hidden" data-auth-user></div>
+          <button class="btn ghost is-hidden" type="button" data-auth-logout>Sign Out</button>
+        </div>
+      </nav>
+    </header>
+
+    <main class="schedule-page">
+      <section class="schedule-hero">
+        <div>
+          <p class="tag">Splatoon 3 • Event Calendar</p>
+          <h1>Schedule list</h1>
+          <p class="subhead">
+            Track every qualifier, scrim, and main stage match in one timeline. Sync reminders and
+            never miss a bracket update.
+          </p>
+        </div>
+        <div class="schedule-actions">
+          <button class="btn secondary">Filter by region</button>
+          <button class="btn ghost">Add to calendar</button>
+        </div>
+      </section>
+
+      <section class="schedule-list" id="schedule-list"></section>
+      <p class="helper-text" id="schedule-status" aria-live="polite"></p>
+    </main>
+
+    <footer class="footer">
+      <div>
+        <h3>Want schedule alerts?</h3>
+        <p>Enable notifications so you never miss a broadcast.</p>
+      </div>
+      <button class="btn primary">Enable alerts</button>
+    </footer>
+
+    <script src="schedule.js" defer></script>
+    <script src="auth.js"></script>
+  </body>
+</html>

--- a/schedule.js
+++ b/schedule.js
@@ -1,0 +1,165 @@
+const scheduleList = document.querySelector('#schedule-list');
+const scheduleStatus = document.querySelector('#schedule-status');
+
+const POLL_INTERVAL_MS = 20000;
+let pollHandle;
+
+const setStatus = (message, type = 'info') => {
+  if (!scheduleStatus) {
+    return;
+  }
+  scheduleStatus.textContent = message;
+  if (type === 'error' || type === 'success') {
+    scheduleStatus.dataset.status = type;
+  } else {
+    scheduleStatus.removeAttribute('data-status');
+  }
+};
+
+const formatScheduleDate = (value) => {
+  if (!value) {
+    return { day: 'TBD', time: 'Time TBD' };
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return { day: 'TBD', time: 'Time TBD' };
+  }
+
+  const day = date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: '2-digit',
+  });
+  const time = date.toLocaleTimeString(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+  return { day, time };
+};
+
+const formatStatus = (status) => {
+  const normalized = (status ?? 'scheduled').toLowerCase();
+  switch (normalized) {
+    case 'live':
+    case 'in_progress':
+      return { label: 'Live now', className: 'status-pill open' };
+    case 'complete':
+    case 'completed':
+      return { label: 'Completed', className: 'status-pill' };
+    case 'final':
+      return { label: 'Final', className: 'status-pill' };
+    case 'scheduled':
+    default:
+      return { label: 'Scheduled', className: 'status-pill open' };
+  }
+};
+
+const renderSchedule = (items) => {
+  if (!scheduleList) {
+    return;
+  }
+
+  if (!Array.isArray(items) || items.length === 0) {
+    scheduleList.innerHTML = `
+      <article class="schedule-row">
+        <div class="schedule-date">
+          <span class="day">TBD</span>
+          <span class="time">Awaiting schedule</span>
+        </div>
+        <div class="schedule-info">
+          <h2>No matches scheduled</h2>
+          <p>Check back soon for updated match times.</p>
+        </div>
+        <div class="schedule-meta">
+          <span class="status-pill">Pending</span>
+          <button class="btn ghost" disabled>Await update</button>
+        </div>
+      </article>
+    `;
+    setStatus('Waiting for schedule updates.', 'info');
+    return;
+  }
+
+  scheduleList.innerHTML = items
+    .map((item) => {
+      const { day, time } = formatScheduleDate(item.scheduled_at);
+      const status = formatStatus(item.status);
+      const eventTitle = item.event_name ?? 'Main Stage';
+      const tournamentName = item.tournament_name ?? 'Arcadia Clash';
+      const format = item.format ?? 'Match';
+      const matchup =
+        item.home_team_name && item.away_team_name
+          ? `${item.home_team_name} vs ${item.away_team_name}`
+          : 'Teams TBD';
+
+      return `
+        <article class="schedule-row">
+          <div class="schedule-date">
+            <span class="day">${day}</span>
+            <span class="time">${time}</span>
+          </div>
+          <div class="schedule-info">
+            <h2>${eventTitle}</h2>
+            <p>${format} · ${tournamentName} · ${matchup}</p>
+          </div>
+          <div class="schedule-meta">
+            <span class="${status.className}">${status.label}</span>
+            <button class="btn ghost">View details</button>
+          </div>
+        </article>
+      `;
+    })
+    .join('');
+
+  setStatus(`Schedule updated at ${new Date().toLocaleTimeString()}.`, 'success');
+};
+
+const loadSchedule = async () => {
+  if (!scheduleList) {
+    return;
+  }
+
+  try {
+    const response = await fetch('/api/schedule');
+    if (!response.ok) {
+      renderSchedule([]);
+      setStatus('Schedule is unavailable right now.', 'error');
+      return;
+    }
+
+    const items = await response.json();
+    renderSchedule(items);
+  } catch (error) {
+    renderSchedule([]);
+    setStatus('Schedule is unavailable right now.', 'error');
+  }
+};
+
+const startPolling = () => {
+  if (pollHandle) {
+    return;
+  }
+  pollHandle = window.setInterval(() => {
+    loadSchedule();
+  }, POLL_INTERVAL_MS);
+};
+
+const stopPolling = () => {
+  if (!pollHandle) {
+    return;
+  }
+  window.clearInterval(pollHandle);
+  pollHandle = null;
+};
+
+loadSchedule();
+startPolling();
+
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden) {
+    stopPolling();
+  } else {
+    loadSchedule();
+    startPolling();
+  }
+});

--- a/seeding.html
+++ b/seeding.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Arcadia Clash is a competitive tournament hub for managing brackets, teams, and live matches." />
+    <meta property="og:title" content="Arcadia Clash - Tournament Hub" />
+    <meta property="og:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://arcadiaclash.gg/" />
+    <meta property="og:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Arcadia Clash - Tournament Hub" />
+    <meta name="twitter:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta name="twitter:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <title>Arcadia Clash - Bracket Seeding</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ARCADIA-0001"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-ARCADIA-0001");
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav">
+        <a class="logo" href="index.html">
+          <span class="logo-mark">AC</span>
+          <span class="logo-text">Arcadia Clash</span>
+        </a>
+        <div class="nav-links">
+          <a href="index.html#features">Features</a>
+          <a href="index.html#brackets">Brackets</a>
+          <a href="index.html#schedule">Schedule</a>
+          <a href="index.html#community">Community</a>
+          <a href="signup.html">Sign Up</a>
+          <a href="user-signup.html">User Sign Up</a>
+          <a href="schedule.html">Schedule List</a>
+          <a href="faq.html">FAQ</a>
+          <a href="team-management.html">Team Management</a>
+          <a href="player-dashboard.html">Player Dashboard</a>
+          <a href="player-profile.html">Player Profile</a>
+          <a href="team-profile.html">Team Profile</a>
+          <a href="match-center.html">Match Center</a>
+          <a href="event-detail.html">Event Detail</a>
+          <a href="tickets.html">Tickets</a>
+          <a href="support.html">Support</a>
+          <a href="rules.html">Rules</a>
+          <a href="standings.html">Standings</a>
+          <a href="admin-console.html">Admin Console</a>
+          <a href="seeding.html" class="active">Seeding</a>
+        </div>
+        <div class="auth-status" data-auth-status>
+          <a class="btn ghost" href="login.html" data-auth-signin>Sign In</a>
+          <div class="auth-user is-hidden" data-auth-user></div>
+          <button class="btn ghost is-hidden" type="button" data-auth-logout>Sign Out</button>
+        </div>
+      </nav>
+    </header>
+
+    <main class="seeding">
+      <section class="seeding-hero">
+        <div>
+          <p class="tag">Splatoon 3 • Bracket Setup</p>
+          <h1>Seed the bracket before the ink hits the floor.</h1>
+          <p class="subhead">
+            Review team performance, apply seed locks, and generate the final bracket order for the
+            Splatoon 3 Turf War Showdown.
+          </p>
+        </div>
+        <div class="seeding-actions">
+          <button class="btn primary">Auto-seed by rank</button>
+          <button class="btn secondary">Import standings CSV</button>
+        </div>
+      </section>
+
+      <section class="seeding-grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Seeding queue</h2>
+            <button class="btn ghost">Shuffle</button>
+          </div>
+          <ul class="seed-list">
+            <li>
+              <span class="seed">#1</span>
+              <div>
+                <h3>Crimson Circuit</h3>
+                <p>4-0 record · +28 ink ratio</p>
+              </div>
+              <span class="status locked">Locked</span>
+            </li>
+            <li>
+              <span class="seed">#2</span>
+              <div>
+                <h3>Nebula Wolves</h3>
+                <p>3-1 record · +18 ink ratio</p>
+              </div>
+              <span class="status">Pending</span>
+            </li>
+            <li>
+              <span class="seed">#3</span>
+              <div>
+                <h3>Neon Nautilus</h3>
+                <p>3-1 record · +14 ink ratio</p>
+              </div>
+              <span class="status">Pending</span>
+            </li>
+            <li>
+              <span class="seed">#4</span>
+              <div>
+                <h3>Lagoon Legends</h3>
+                <p>2-2 record · +6 ink ratio</p>
+              </div>
+              <span class="status locked">Locked</span>
+            </li>
+            <li>
+              <span class="seed">#5</span>
+              <div>
+                <h3>Solar Splatter</h3>
+                <p>2-2 record · +4 ink ratio</p>
+              </div>
+              <span class="status">Pending</span>
+            </li>
+            <li>
+              <span class="seed">#6</span>
+              <div>
+                <h3>Tidal Tempest</h3>
+                <p>1-3 record · -8 ink ratio</p>
+              </div>
+              <span class="status">Pending</span>
+            </li>
+          </ul>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Bracket preview</h2>
+            <button class="btn ghost">Export PDF</button>
+          </div>
+          <div class="bracket-preview">
+            <div class="bracket-round">
+              <h3>Quarterfinals</h3>
+              <div class="match">
+                <span>Crimson Circuit</span>
+                <span class="vs">vs</span>
+                <span>Tidal Tempest</span>
+              </div>
+              <div class="match">
+                <span>Nebula Wolves</span>
+                <span class="vs">vs</span>
+                <span>Solar Splatter</span>
+              </div>
+              <div class="match">
+                <span>Neon Nautilus</span>
+                <span class="vs">vs</span>
+                <span>Lagoon Legends</span>
+              </div>
+              <div class="match">
+                <span>Wildcard Winner</span>
+                <span class="vs">vs</span>
+                <span>Qualifier #2</span>
+              </div>
+            </div>
+            <div class="bracket-round">
+              <h3>Semifinals</h3>
+              <div class="match dim">Match 5 Winner vs Match 6 Winner</div>
+              <div class="match dim">Match 7 Winner vs Match 8 Winner</div>
+            </div>
+            <div class="bracket-round">
+              <h3>Finals</h3>
+              <div class="match dim">Winners advance to Grand Finals</div>
+            </div>
+          </div>
+          <div class="seeding-summary">
+            <div>
+              <h4>Seed locks</h4>
+              <p>2 locked · 4 pending</p>
+            </div>
+            <div>
+              <h4>Bracket type</h4>
+              <p>Double elimination</p>
+            </div>
+            <div>
+              <h4>Next step</h4>
+              <p>Publish bracket by Apr 12</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div>
+        <h3>Ready to publish the bracket?</h3>
+        <p>Lock in the seeds and notify teams once the bracket goes live.</p>
+      </div>
+      <button class="btn primary">Publish bracket</button>
+    </footer>
+    <script src="auth.js"></script>
+  </body>
+</html>

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,5 @@
+DB_PATH=./data/arcadia.db
+JWT_SECRET=change-me
+COOKIE_SECRET=change-me
+PORT=3001
+HOST=0.0.0.0

--- a/server/.env.production.example
+++ b/server/.env.production.example
@@ -1,0 +1,6 @@
+NODE_ENV=production
+HOST=0.0.0.0
+PORT=3001
+JWT_SECRET=change-me
+COOKIE_SECRET=change-me
+DB_PATH=./data/arcadia.db

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,65 @@
+# Arcadia Clash Backend
+
+This service runs the Fastify-based backend for the tournament platform.
+
+## Scripts
+
+```bash
+npm install
+npm run dev
+```
+
+## Database
+
+The service uses a local SQLite database by default at `./data/arcadia.db`.
+You can override the path with `DB_PATH`.
+
+```bash
+DB_PATH=./data/arcadia.db npm run dev
+```
+
+## Authentication
+
+Set `JWT_SECRET` in your environment for signing login tokens and `COOKIE_SECRET` for session cookies.
+
+Authentication now uses a short-lived access token plus a secure refresh cookie. The refresh cookie is
+HTTP-only and used by `/api/auth/session` and `/api/auth/refresh` to mint new access tokens. Use
+the returned `csrfToken` for state-changing requests that hit cookie-based auth endpoints.
+
+## Endpoints
+
+- `GET /health` — basic health check
+- `GET /api/status` — service metadata
+- `GET /api/db-status` — database connectivity check
+- `POST /api/auth/register` — create user account
+- `POST /api/auth/login` — authenticate and receive JWT
+- `GET /api/auth/session` — load session via refresh cookie
+- `POST /api/auth/refresh` — refresh access token (requires CSRF)
+- `POST /api/auth/logout` — clear session (requires CSRF)
+- `GET /api/me` — current user profile (requires JWT)
+- `GET /api/users` — list users
+- `POST /api/users` — create user
+- `GET /api/teams` — list teams
+- `POST /api/teams` — create team
+- `POST /api/teams/:teamId/members` — add team member
+- `GET /api/roles` — list roles
+- `POST /api/roles` — create role
+- `POST /api/users/:userId/roles` — assign role to user
+- `GET /api/tournaments` — list tournaments
+- `POST /api/tournaments` — create tournament
+- `GET /api/events` — list events
+- `POST /api/events` — create event
+- `GET /api/schedule` — list scheduled matches
+- `GET /api/matches` — list matches
+- `GET /api/matches/latest` — latest match with scores
+- `POST /api/matches` — create match
+- `POST /api/matches/:matchId/result` — add/update match result
+- `GET /api/standings` — list standings
+- `POST /api/registrations` — register team for tournament
+- `GET /api/brackets` — list brackets
+- `POST /api/brackets` — create bracket
+- `GET /api/support/tickets` — list support tickets (admin only)
+- `POST /api/support/tickets` — create support ticket
+- `GET /api/admin/actions` — list admin actions
+- `POST /api/admin/actions` — log admin action
+- `POST /api/tournament-signups` — submit tournament signup interest

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "arcadia-clash-backend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node src/index.js",
+    "start": "node src/index.js",
+    "smoke-test": "node scripts/smoke-test.mjs"
+  },
+  "dependencies": {
+    "@fastify/cookie": "^9.2.0",
+    "@fastify/jwt": "^7.2.0",
+    "bcryptjs": "^2.4.3",
+    "fastify": "^4.26.2",
+    "sqlite": "^5.1.1",
+    "sqlite3": "^5.1.7"
+  }
+}

--- a/server/scripts/smoke-test.mjs
+++ b/server/scripts/smoke-test.mjs
@@ -1,0 +1,37 @@
+import { setTimeout as delay } from 'node:timers/promises';
+
+const baseUrl = process.env.API_BASE_URL ?? 'http://127.0.0.1:3001';
+
+const waitForServer = async () => {
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/health`);
+      if (response.ok) {
+        return;
+      }
+    } catch (error) {
+      // ignore
+    }
+    await delay(500);
+  }
+  throw new Error(`Server not reachable at ${baseUrl}`);
+};
+
+const assertOk = async (path) => {
+  const response = await fetch(`${baseUrl}${path}`);
+  if (!response.ok) {
+    throw new Error(`${path} returned ${response.status}`);
+  }
+};
+
+const run = async () => {
+  await waitForServer();
+  await assertOk('/health');
+  await assertOk('/api/status');
+  console.log('Smoke tests passed.');
+};
+
+run().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/server/src/db.js
+++ b/server/src/db.js
@@ -1,0 +1,188 @@
+import { mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import sqlite3 from 'sqlite3';
+import { open } from 'sqlite';
+
+const DEFAULT_DB_PATH = './data/arcadia.db';
+
+export const initDatabase = async () => {
+  const databasePath = process.env.DB_PATH ?? DEFAULT_DB_PATH;
+  const resolvedPath = resolve(databasePath);
+
+  await mkdir(dirname(resolvedPath), { recursive: true });
+
+  const db = await open({
+    filename: resolvedPath,
+    driver: sqlite3.Database,
+  });
+
+  await db.exec(`
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT NOT NULL UNIQUE,
+      display_name TEXT NOT NULL,
+      password_hash TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS teams (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL UNIQUE,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS team_members (
+      team_id INTEGER NOT NULL,
+      user_id INTEGER NOT NULL,
+      role TEXT NOT NULL,
+      joined_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (team_id, user_id),
+      FOREIGN KEY (team_id) REFERENCES teams (id) ON DELETE CASCADE,
+      FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS roles (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL UNIQUE,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS user_roles (
+      user_id INTEGER NOT NULL,
+      role_id INTEGER NOT NULL,
+      assigned_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (user_id, role_id),
+      FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
+      FOREIGN KEY (role_id) REFERENCES roles (id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS tournaments (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'draft',
+      starts_at TEXT,
+      ends_at TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      tournament_id INTEGER NOT NULL,
+      name TEXT NOT NULL,
+      game TEXT NOT NULL,
+      format TEXT NOT NULL,
+      starts_at TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (tournament_id) REFERENCES tournaments (id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS registrations (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      tournament_id INTEGER NOT NULL,
+      team_id INTEGER NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE (tournament_id, team_id),
+      FOREIGN KEY (tournament_id) REFERENCES tournaments (id) ON DELETE CASCADE,
+      FOREIGN KEY (team_id) REFERENCES teams (id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS matches (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      event_id INTEGER NOT NULL,
+      round INTEGER NOT NULL DEFAULT 1,
+      scheduled_at TEXT,
+      status TEXT NOT NULL DEFAULT 'scheduled',
+      home_team_id INTEGER,
+      away_team_id INTEGER,
+      winner_team_id INTEGER,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (event_id) REFERENCES events (id) ON DELETE CASCADE,
+      FOREIGN KEY (home_team_id) REFERENCES teams (id) ON DELETE SET NULL,
+      FOREIGN KEY (away_team_id) REFERENCES teams (id) ON DELETE SET NULL,
+      FOREIGN KEY (winner_team_id) REFERENCES teams (id) ON DELETE SET NULL
+    );
+    CREATE TABLE IF NOT EXISTS match_results (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      match_id INTEGER NOT NULL UNIQUE,
+      home_score INTEGER NOT NULL DEFAULT 0,
+      away_score INTEGER NOT NULL DEFAULT 0,
+      notes TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (match_id) REFERENCES matches (id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS brackets (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      event_id INTEGER NOT NULL,
+      name TEXT NOT NULL,
+      bracket_type TEXT NOT NULL DEFAULT 'single_elimination',
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (event_id) REFERENCES events (id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS support_tickets (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER,
+      subject TEXT NOT NULL,
+      message TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'open',
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE SET NULL
+    );
+    CREATE TABLE IF NOT EXISTS admin_actions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      actor_user_id INTEGER,
+      action TEXT NOT NULL,
+      target_type TEXT,
+      target_id INTEGER,
+      notes TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (actor_user_id) REFERENCES users (id) ON DELETE SET NULL
+    );
+    CREATE TABLE IF NOT EXISTS tournament_signups (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      signup_type TEXT NOT NULL,
+      player_handle TEXT,
+      email TEXT,
+      region TEXT,
+      role_preference TEXT,
+      availability TEXT,
+      team_name TEXT,
+      captain_name TEXT,
+      captain_email TEXT,
+      team_size TEXT,
+      time_slot TEXT,
+      contact_handle TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS standings (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      team_id INTEGER NOT NULL UNIQUE,
+      wins INTEGER NOT NULL DEFAULT 0,
+      losses INTEGER NOT NULL DEFAULT 0,
+      seed_points INTEGER NOT NULL DEFAULT 0,
+      streak TEXT,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (team_id) REFERENCES teams (id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS user_sessions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      refresh_token_hash TEXT NOT NULL UNIQUE,
+      csrf_token TEXT NOT NULL,
+      expires_at TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+    );
+  `);
+
+  const userColumns = await db.all('PRAGMA table_info(users)');
+  const hasPasswordHash = userColumns.some((column) => column.name === 'password_hash');
+  if (!hasPasswordHash) {
+    await db.exec('ALTER TABLE users ADD COLUMN password_hash TEXT;');
+  }
+
+  const roleCount = await db.get('SELECT COUNT(*) AS count FROM roles');
+  if (roleCount?.count === 0) {
+    await db.run('INSERT INTO roles (name) VALUES (?), (?), (?), (?)', [
+      'Player',
+      'Captain',
+      'Organizer',
+      'Admin/Staff',
+    ]);
+  }
+
+  return { db, resolvedPath };
+};

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,0 +1,55 @@
+import Fastify from 'fastify';
+import jwt from '@fastify/jwt';
+import cookie from '@fastify/cookie';
+
+import { initDatabase } from './db.js';
+import { registerApiRoutes } from './routes.js';
+
+const app = Fastify({
+  logger: true,
+});
+
+app.get('/health', async () => {
+  return { status: 'ok' };
+});
+
+app.get('/api/status', async () => {
+  return {
+    service: 'Arcadia Clash Backend',
+    version: '0.1.0',
+    environment: process.env.NODE_ENV ?? 'development',
+  };
+});
+
+const start = async () => {
+  try {
+    const port = Number(process.env.PORT ?? 3001);
+    const host = process.env.HOST ?? '0.0.0.0';
+    const { db, resolvedPath } = await initDatabase();
+
+    app.decorate('db', db);
+    app.decorate('dbPath', resolvedPath);
+
+    await app.register(cookie, {
+      secret: process.env.COOKIE_SECRET ?? 'dev-cookie-secret-change-me',
+    });
+
+    await app.register(jwt, {
+      secret: process.env.JWT_SECRET ?? 'dev-secret-change-me',
+    });
+
+    app.addHook('onClose', async (instance) => {
+      await instance.db.close();
+    });
+
+    registerApiRoutes(app);
+
+    await app.listen({ port, host });
+    app.log.info(`Server listening on http://${host}:${port}`);
+  } catch (error) {
+    app.log.error(error);
+    process.exit(1);
+  }
+};
+
+start();

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -1,0 +1,740 @@
+import bcrypt from 'bcryptjs';
+import crypto from 'node:crypto';
+
+const requireFields = (payload, fields) => {
+  const missing = fields.filter((field) => !payload?.[field]);
+  if (missing.length) {
+    return { ok: false, missing };
+  }
+  return { ok: true };
+};
+
+export const registerApiRoutes = (app) => {
+  const REFRESH_COOKIE = 'arcadia_refresh';
+  const ACCESS_TOKEN_TTL = '15m';
+  const SESSION_TTL_DAYS = 30;
+
+  const hashToken = (value) => crypto.createHash('sha256').update(value).digest('hex');
+
+  const createSession = async (userId) => {
+    const refreshToken = crypto.randomBytes(48).toString('hex');
+    const csrfToken = crypto.randomBytes(32).toString('hex');
+    const refreshTokenHash = hashToken(refreshToken);
+    const expiresAt = new Date(Date.now() + SESSION_TTL_DAYS * 24 * 60 * 60 * 1000).toISOString();
+
+    await app.db.run(
+      `INSERT INTO user_sessions (user_id, refresh_token_hash, csrf_token, expires_at)
+       VALUES (?, ?, ?, ?)`,
+      [userId, refreshTokenHash, csrfToken, expiresAt]
+    );
+
+    return { refreshToken, csrfToken, expiresAt };
+  };
+
+  const getSessionFromRequest = async (request) => {
+    const refreshToken = request.cookies?.[REFRESH_COOKIE];
+    if (!refreshToken) {
+      return null;
+    }
+    const refreshTokenHash = hashToken(refreshToken);
+    const session = await app.db.get(
+      `SELECT id, user_id, refresh_token_hash, csrf_token, expires_at
+         FROM user_sessions
+        WHERE refresh_token_hash = ?`,
+      [refreshTokenHash]
+    );
+    if (!session) {
+      return null;
+    }
+
+    if (new Date(session.expires_at).getTime() < Date.now()) {
+      await app.db.run('DELETE FROM user_sessions WHERE id = ?', [session.id]);
+      return null;
+    }
+
+    return session;
+  };
+
+  const requireCsrf = (request, reply, session) => {
+    const csrfHeader = request.headers['x-csrf-token'];
+    if (!csrfHeader || csrfHeader !== session?.csrf_token) {
+      reply.code(403).send({ error: 'Invalid CSRF token' });
+      return false;
+    }
+    return true;
+  };
+
+  const issueAccessToken = (user) =>
+    app.jwt.sign({ id: user.id, email: user.email }, { expiresIn: ACCESS_TOKEN_TTL });
+
+  app.decorate('authenticate', async (request, reply) => {
+    try {
+      await request.jwtVerify();
+    } catch (error) {
+      return reply.code(401).send({ error: 'Unauthorized' });
+    }
+  });
+
+  const requireRoles = (allowedRoles) => async (request, reply) => {
+    await app.authenticate(request, reply);
+    if (reply.sent) {
+      return;
+    }
+
+    const userId = request.user?.id;
+    if (!userId) {
+      return reply.code(401).send({ error: 'Unauthorized' });
+    }
+
+    const roles = await app.db.all(
+      `SELECT roles.name
+         FROM user_roles
+         JOIN roles ON roles.id = user_roles.role_id
+        WHERE user_roles.user_id = ?`,
+      [userId]
+    );
+    const roleNames = roles.map((role) => role.name);
+    const hasRole = allowedRoles.some((role) => roleNames.includes(role));
+    if (!hasRole) {
+      return reply.code(403).send({ error: 'Forbidden' });
+    }
+  };
+
+  app.get('/api/db-status', async () => {
+    const row = await app.db.get('SELECT 1 AS ok');
+    return {
+      ok: row?.ok === 1,
+      path: app.dbPath,
+    };
+  });
+
+  app.post('/api/auth/register', async (request, reply) => {
+    const { email, displayName, password } = request.body ?? {};
+    const validation = requireFields({ email, displayName, password }, [
+      'email',
+      'displayName',
+      'password',
+    ]);
+    if (!validation.ok) {
+      return reply.code(400).send({ error: 'Missing required fields', missing: validation.missing });
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 10);
+    try {
+      const result = await app.db.run(
+        'INSERT INTO users (email, display_name, password_hash) VALUES (?, ?, ?)',
+        [email, displayName, hashedPassword]
+      );
+      const playerRole = await app.db.get('SELECT id FROM roles WHERE name = ?', ['Player']);
+      if (playerRole?.id) {
+        await app.db.run('INSERT INTO user_roles (user_id, role_id) VALUES (?, ?)', [
+          result.lastID,
+          playerRole.id,
+        ]);
+      }
+      return reply.code(201).send({ id: result.lastID });
+    } catch (error) {
+      return reply.code(409).send({ error: 'User already exists' });
+    }
+  });
+
+  app.post('/api/auth/login', async (request, reply) => {
+    const { email, password } = request.body ?? {};
+    const validation = requireFields({ email, password }, ['email', 'password']);
+    if (!validation.ok) {
+      return reply.code(400).send({ error: 'Missing required fields', missing: validation.missing });
+    }
+
+    const user = await app.db.get(
+      'SELECT id, email, display_name, password_hash FROM users WHERE email = ?',
+      [email]
+    );
+    if (!user?.password_hash) {
+      return reply.code(401).send({ error: 'Invalid credentials' });
+    }
+
+    const isValid = await bcrypt.compare(password, user.password_hash);
+    if (!isValid) {
+      return reply.code(401).send({ error: 'Invalid credentials' });
+    }
+
+    const { refreshToken, csrfToken, expiresAt } = await createSession(user.id);
+    reply.setCookie(REFRESH_COOKIE, refreshToken, {
+      path: '/',
+      httpOnly: true,
+      sameSite: 'strict',
+      secure: process.env.NODE_ENV === 'production',
+      expires: new Date(expiresAt),
+    });
+
+    const accessToken = issueAccessToken(user);
+    return reply.send({
+      token: accessToken,
+      csrfToken,
+      user: { id: user.id, email: user.email, displayName: user.display_name },
+    });
+  });
+
+  app.get('/api/auth/session', async (request, reply) => {
+    const session = await getSessionFromRequest(request);
+    if (!session) {
+      return reply.code(401).send({ error: 'Unauthorized' });
+    }
+
+    const user = await app.db.get(
+      'SELECT id, email, display_name, created_at FROM users WHERE id = ?',
+      [session.user_id]
+    );
+    if (!user) {
+      return reply.code(401).send({ error: 'Unauthorized' });
+    }
+
+    const roles = await app.db.all(
+      `SELECT roles.name
+         FROM user_roles
+         JOIN roles ON roles.id = user_roles.role_id
+        WHERE user_roles.user_id = ?`,
+      [session.user_id]
+    );
+
+    const accessToken = issueAccessToken(user);
+    return reply.send({
+      token: accessToken,
+      csrfToken: session.csrf_token,
+      user: {
+        id: user.id,
+        email: user.email,
+        displayName: user.display_name,
+        created_at: user.created_at,
+        roles: roles.map((role) => role.name),
+      },
+    });
+  });
+
+  app.post('/api/auth/refresh', async (request, reply) => {
+    const session = await getSessionFromRequest(request);
+    if (!session) {
+      return reply.code(401).send({ error: 'Unauthorized' });
+    }
+    if (!requireCsrf(request, reply, session)) {
+      return;
+    }
+
+    const user = await app.db.get(
+      'SELECT id, email, display_name, created_at FROM users WHERE id = ?',
+      [session.user_id]
+    );
+    if (!user) {
+      return reply.code(401).send({ error: 'Unauthorized' });
+    }
+
+    const accessToken = issueAccessToken(user);
+    return reply.send({ token: accessToken });
+  });
+
+  app.post('/api/auth/logout', async (request, reply) => {
+    const session = await getSessionFromRequest(request);
+    if (!session) {
+      reply.clearCookie(REFRESH_COOKIE, { path: '/' });
+      return reply.send({ ok: true });
+    }
+    if (!requireCsrf(request, reply, session)) {
+      return;
+    }
+
+    await app.db.run('DELETE FROM user_sessions WHERE id = ?', [session.id]);
+    reply.clearCookie(REFRESH_COOKIE, { path: '/' });
+    return reply.send({ ok: true });
+  });
+
+  app.get('/api/me', { preHandler: [app.authenticate] }, async (request) => {
+    const user = await app.db.get(
+      'SELECT id, email, display_name, created_at FROM users WHERE id = ?',
+      [request.user.id]
+    );
+    if (!user) {
+      return { user: null };
+    }
+
+    const roles = await app.db.all(
+      `SELECT roles.name
+         FROM user_roles
+         JOIN roles ON roles.id = user_roles.role_id
+        WHERE user_roles.user_id = ?`,
+      [request.user.id]
+    );
+
+    return {
+      user: {
+        id: user.id,
+        email: user.email,
+        displayName: user.display_name,
+        created_at: user.created_at,
+        roles: roles.map((role) => role.name),
+      },
+    };
+  });
+
+  app.get('/api/users', { preHandler: [requireRoles(['Admin/Staff'])] }, async () => {
+    return app.db.all(
+      'SELECT id, email, display_name, created_at FROM users ORDER BY created_at DESC'
+    );
+  });
+
+  app.post('/api/users', { preHandler: [requireRoles(['Admin/Staff'])] }, async (request, reply) => {
+    const { email, displayName } = request.body ?? {};
+    const validation = requireFields({ email, displayName }, ['email', 'displayName']);
+    if (!validation.ok) {
+      return reply.code(400).send({ error: 'Missing required fields', missing: validation.missing });
+    }
+
+    const result = await app.db.run(
+      'INSERT INTO users (email, display_name) VALUES (?, ?)',
+      [email, displayName]
+    );
+    return reply.code(201).send({ id: result.lastID });
+  });
+
+  app.get('/api/teams', async () => {
+    return app.db.all('SELECT id, name, created_at FROM teams ORDER BY created_at DESC');
+  });
+
+  app.post('/api/teams', async (request, reply) => {
+    const { name } = request.body ?? {};
+    const validation = requireFields({ name }, ['name']);
+    if (!validation.ok) {
+      return reply.code(400).send({ error: 'Missing required fields', missing: validation.missing });
+    }
+
+    const result = await app.db.run('INSERT INTO teams (name) VALUES (?)', [name]);
+    return reply.code(201).send({ id: result.lastID });
+  });
+
+  app.post(
+    '/api/teams/:teamId/members',
+    { preHandler: [requireRoles(['Captain', 'Organizer', 'Admin/Staff'])] },
+    async (request, reply) => {
+      const { teamId } = request.params ?? {};
+      const { userId, role } = request.body ?? {};
+      const validation = requireFields({ userId, role }, ['userId', 'role']);
+      if (!validation.ok) {
+        return reply
+          .code(400)
+          .send({ error: 'Missing required fields', missing: validation.missing });
+      }
+
+      await app.db.run(
+        'INSERT OR REPLACE INTO team_members (team_id, user_id, role) VALUES (?, ?, ?)',
+        [teamId, userId, role]
+      );
+      return reply.code(201).send({ teamId: Number(teamId), userId, role });
+    }
+  );
+
+  app.get('/api/roles', { preHandler: [requireRoles(['Admin/Staff', 'Organizer'])] }, async () => {
+    return app.db.all('SELECT id, name, created_at FROM roles ORDER BY name');
+  });
+
+  app.post('/api/roles', { preHandler: [requireRoles(['Admin/Staff'])] }, async (request, reply) => {
+    const { name } = request.body ?? {};
+    const validation = requireFields({ name }, ['name']);
+    if (!validation.ok) {
+      return reply.code(400).send({ error: 'Missing required fields', missing: validation.missing });
+    }
+
+    const result = await app.db.run('INSERT INTO roles (name) VALUES (?)', [name]);
+    return reply.code(201).send({ id: result.lastID });
+  });
+
+  app.post(
+    '/api/users/:userId/roles',
+    { preHandler: [requireRoles(['Admin/Staff'])] },
+    async (request, reply) => {
+      const { userId } = request.params ?? {};
+      const { roleId } = request.body ?? {};
+      const validation = requireFields({ roleId }, ['roleId']);
+      if (!validation.ok) {
+        return reply.code(400).send({ error: 'Missing required fields', missing: validation.missing });
+      }
+
+      await app.db.run(
+        'INSERT OR REPLACE INTO user_roles (user_id, role_id) VALUES (?, ?)',
+        [userId, roleId]
+      );
+      return reply.code(201).send({ userId: Number(userId), roleId });
+    }
+  );
+
+  app.get('/api/tournaments', async () => {
+    return app.db.all(
+      'SELECT id, name, status, starts_at, ends_at, created_at FROM tournaments ORDER BY created_at DESC'
+    );
+  });
+
+  app.post(
+    '/api/tournaments',
+    { preHandler: [requireRoles(['Organizer', 'Admin/Staff'])] },
+    async (request, reply) => {
+      const { name, status, startsAt, endsAt } = request.body ?? {};
+      const validation = requireFields({ name }, ['name']);
+      if (!validation.ok) {
+        return reply
+          .code(400)
+          .send({ error: 'Missing required fields', missing: validation.missing });
+      }
+
+      const result = await app.db.run(
+        'INSERT INTO tournaments (name, status, starts_at, ends_at) VALUES (?, ?, ?, ?)',
+        [name, status ?? 'draft', startsAt ?? null, endsAt ?? null]
+      );
+      return reply.code(201).send({ id: result.lastID });
+    }
+  );
+
+  app.get('/api/events', async () => {
+    return app.db.all(
+      `SELECT events.id, events.tournament_id, events.name, events.game, events.format,
+              events.starts_at, events.created_at, tournaments.name AS tournament_name
+         FROM events
+         JOIN tournaments ON tournaments.id = events.tournament_id
+     ORDER BY events.created_at DESC`
+    );
+  });
+
+  app.post(
+    '/api/events',
+    { preHandler: [requireRoles(['Organizer', 'Admin/Staff'])] },
+    async (request, reply) => {
+      const { tournamentId, name, game, format, startsAt } = request.body ?? {};
+      const validation = requireFields(
+        { tournamentId, name, game, format },
+        ['tournamentId', 'name', 'game', 'format']
+      );
+      if (!validation.ok) {
+        return reply
+          .code(400)
+          .send({ error: 'Missing required fields', missing: validation.missing });
+      }
+
+      const result = await app.db.run(
+        'INSERT INTO events (tournament_id, name, game, format, starts_at) VALUES (?, ?, ?, ?, ?)',
+        [tournamentId, name, game, format, startsAt ?? null]
+      );
+      return reply.code(201).send({ id: result.lastID });
+    }
+  );
+
+  app.get('/api/schedule', async () => {
+    return app.db.all(
+      `SELECT matches.id, matches.event_id, matches.round, matches.scheduled_at, matches.status,
+              events.name AS event_name,
+              events.format,
+              tournaments.name AS tournament_name,
+              home_team.name AS home_team_name,
+              away_team.name AS away_team_name
+         FROM matches
+         JOIN events ON events.id = matches.event_id
+         JOIN tournaments ON tournaments.id = events.tournament_id
+         LEFT JOIN teams AS home_team ON home_team.id = matches.home_team_id
+         LEFT JOIN teams AS away_team ON away_team.id = matches.away_team_id
+     ORDER BY matches.scheduled_at IS NULL,
+              datetime(matches.scheduled_at) ASC,
+              matches.created_at ASC`
+    );
+  });
+
+  app.get('/api/matches', async () => {
+    return app.db.all(
+      `SELECT matches.id, matches.event_id, matches.round, matches.scheduled_at, matches.status,
+              matches.home_team_id, matches.away_team_id, matches.winner_team_id,
+              events.name AS event_name,
+              home_team.name AS home_team_name,
+              away_team.name AS away_team_name,
+              match_results.home_score,
+              match_results.away_score
+         FROM matches
+         JOIN events ON events.id = matches.event_id
+         LEFT JOIN teams AS home_team ON home_team.id = matches.home_team_id
+         LEFT JOIN teams AS away_team ON away_team.id = matches.away_team_id
+         LEFT JOIN match_results ON match_results.match_id = matches.id
+     ORDER BY matches.created_at DESC`
+    );
+  });
+
+  app.get('/api/matches/latest', async (request, reply) => {
+    const match = await app.db.get(
+      `SELECT matches.id, matches.event_id, matches.round, matches.scheduled_at, matches.status,
+              matches.home_team_id, matches.away_team_id, matches.winner_team_id,
+              events.name AS event_name,
+              home_team.name AS home_team_name,
+              away_team.name AS away_team_name,
+              match_results.home_score,
+              match_results.away_score
+         FROM matches
+         JOIN events ON events.id = matches.event_id
+         LEFT JOIN teams AS home_team ON home_team.id = matches.home_team_id
+         LEFT JOIN teams AS away_team ON away_team.id = matches.away_team_id
+         LEFT JOIN match_results ON match_results.match_id = matches.id
+     ORDER BY matches.created_at DESC
+        LIMIT 1`
+    );
+
+    if (!match) {
+      return reply.code(404).send({ error: 'No matches found' });
+    }
+
+    return match;
+  });
+
+  app.post(
+    '/api/matches',
+    { preHandler: [requireRoles(['Organizer', 'Admin/Staff'])] },
+    async (request, reply) => {
+      const { eventId, round, scheduledAt, status, homeTeamId, awayTeamId } = request.body ?? {};
+      const validation = requireFields({ eventId }, ['eventId']);
+      if (!validation.ok) {
+        return reply
+          .code(400)
+          .send({ error: 'Missing required fields', missing: validation.missing });
+      }
+
+      const result = await app.db.run(
+        `INSERT INTO matches (event_id, round, scheduled_at, status, home_team_id, away_team_id)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+        [
+          eventId,
+          round ?? 1,
+          scheduledAt ?? null,
+          status ?? 'scheduled',
+          homeTeamId ?? null,
+          awayTeamId ?? null,
+        ]
+      );
+      return reply.code(201).send({ id: result.lastID });
+    }
+  );
+
+  app.post(
+    '/api/matches/:matchId/result',
+    { preHandler: [requireRoles(['Organizer', 'Admin/Staff'])] },
+    async (request, reply) => {
+      const { matchId } = request.params ?? {};
+      const { homeScore, awayScore, notes, winnerTeamId } = request.body ?? {};
+      const validation = requireFields({ homeScore, awayScore }, ['homeScore', 'awayScore']);
+      if (!validation.ok) {
+        return reply
+          .code(400)
+          .send({ error: 'Missing required fields', missing: validation.missing });
+      }
+
+      await app.db.run(
+        `INSERT INTO match_results (match_id, home_score, away_score, notes)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT(match_id) DO UPDATE SET
+           home_score = excluded.home_score,
+           away_score = excluded.away_score,
+           notes = excluded.notes`,
+        [matchId, homeScore, awayScore, notes ?? null]
+      );
+
+      if (winnerTeamId) {
+        await app.db.run('UPDATE matches SET winner_team_id = ? WHERE id = ?', [
+          winnerTeamId,
+          matchId,
+        ]);
+      }
+
+      return reply.code(201).send({ matchId: Number(matchId) });
+    }
+  );
+
+  app.get('/api/standings', async () => {
+    return app.db.all(
+      `SELECT standings.id, standings.team_id, standings.wins, standings.losses,
+              standings.seed_points, standings.streak, standings.updated_at,
+              teams.name AS team_name
+         FROM standings
+         JOIN teams ON teams.id = standings.team_id
+     ORDER BY standings.seed_points DESC, standings.wins DESC`
+    );
+  });
+
+  app.post(
+    '/api/registrations',
+    { preHandler: [requireRoles(['Captain', 'Organizer', 'Admin/Staff'])] },
+    async (request, reply) => {
+      const { tournamentId, teamId, status } = request.body ?? {};
+      const validation = requireFields({ tournamentId, teamId }, ['tournamentId', 'teamId']);
+      if (!validation.ok) {
+        return reply
+          .code(400)
+          .send({ error: 'Missing required fields', missing: validation.missing });
+      }
+
+      const result = await app.db.run(
+        'INSERT INTO registrations (tournament_id, team_id, status) VALUES (?, ?, ?)',
+        [tournamentId, teamId, status ?? 'pending']
+      );
+      return reply.code(201).send({ id: result.lastID });
+    }
+  );
+
+  app.get('/api/brackets', async () => {
+    return app.db.all(
+      `SELECT brackets.id, brackets.event_id, brackets.name, brackets.bracket_type, brackets.created_at,
+              events.name AS event_name
+         FROM brackets
+         JOIN events ON events.id = brackets.event_id
+     ORDER BY brackets.created_at DESC`
+    );
+  });
+
+  app.post(
+    '/api/brackets',
+    { preHandler: [requireRoles(['Organizer', 'Admin/Staff'])] },
+    async (request, reply) => {
+      const { eventId, name, bracketType } = request.body ?? {};
+      const validation = requireFields({ eventId, name }, ['eventId', 'name']);
+      if (!validation.ok) {
+        return reply
+          .code(400)
+          .send({ error: 'Missing required fields', missing: validation.missing });
+      }
+
+      const result = await app.db.run(
+        'INSERT INTO brackets (event_id, name, bracket_type) VALUES (?, ?, ?)',
+        [eventId, name, bracketType ?? 'single_elimination']
+      );
+      return reply.code(201).send({ id: result.lastID });
+    }
+  );
+
+  app.get('/api/support/tickets', { preHandler: [requireRoles(['Admin/Staff'])] }, async () => {
+    return app.db.all(
+      `SELECT support_tickets.id, support_tickets.user_id, support_tickets.subject,
+              support_tickets.message, support_tickets.status, support_tickets.created_at,
+              users.email AS user_email
+         FROM support_tickets
+         LEFT JOIN users ON users.id = support_tickets.user_id
+     ORDER BY support_tickets.created_at DESC`
+    );
+  });
+
+  app.post('/api/support/tickets', { preHandler: [app.authenticate] }, async (request, reply) => {
+    const { subject, message } = request.body ?? {};
+    const validation = requireFields({ subject, message }, ['subject', 'message']);
+    if (!validation.ok) {
+      return reply
+        .code(400)
+        .send({ error: 'Missing required fields', missing: validation.missing });
+    }
+
+    const result = await app.db.run(
+      'INSERT INTO support_tickets (user_id, subject, message) VALUES (?, ?, ?)',
+      [request.user.id, subject, message]
+    );
+    return reply.code(201).send({ id: result.lastID });
+  });
+
+  app.get('/api/admin/actions', { preHandler: [requireRoles(['Admin/Staff'])] }, async () => {
+    return app.db.all(
+      `SELECT admin_actions.id, admin_actions.actor_user_id, admin_actions.action,
+              admin_actions.target_type, admin_actions.target_id, admin_actions.notes,
+              admin_actions.created_at, users.email AS actor_email
+         FROM admin_actions
+         LEFT JOIN users ON users.id = admin_actions.actor_user_id
+     ORDER BY admin_actions.created_at DESC`
+    );
+  });
+
+  app.post('/api/admin/actions', { preHandler: [requireRoles(['Admin/Staff'])] }, async (request, reply) => {
+    const { action, targetType, targetId, notes } = request.body ?? {};
+    const validation = requireFields({ action }, ['action']);
+    if (!validation.ok) {
+      return reply
+        .code(400)
+        .send({ error: 'Missing required fields', missing: validation.missing });
+    }
+
+    const result = await app.db.run(
+      `INSERT INTO admin_actions (actor_user_id, action, target_type, target_id, notes)
+       VALUES (?, ?, ?, ?, ?)`,
+      [request.user.id, action, targetType ?? null, targetId ?? null, notes ?? null]
+    );
+    return reply.code(201).send({ id: result.lastID });
+  });
+
+  app.post('/api/tournament-signups', async (request, reply) => {
+    const {
+      type,
+      playerHandle,
+      email,
+      region,
+      rolePreference,
+      availability,
+      teamName,
+      captainName,
+      captainEmail,
+      teamSize,
+      timeSlot,
+      contactHandle,
+    } = request.body ?? {};
+
+    if (type === 'individual') {
+      const validation = requireFields(
+        { playerHandle, email, region, rolePreference, availability },
+        ['playerHandle', 'email', 'region', 'rolePreference', 'availability']
+      );
+      if (!validation.ok) {
+        return reply
+          .code(400)
+          .send({ error: 'Missing required fields', missing: validation.missing });
+      }
+    } else if (type === 'team') {
+      const validation = requireFields(
+        { teamName, captainName, captainEmail, teamSize, timeSlot, contactHandle },
+        ['teamName', 'captainName', 'captainEmail', 'teamSize', 'timeSlot', 'contactHandle']
+      );
+      if (!validation.ok) {
+        return reply
+          .code(400)
+          .send({ error: 'Missing required fields', missing: validation.missing });
+      }
+    } else {
+      return reply.code(400).send({ error: 'Invalid signup type' });
+    }
+
+    const result = await app.db.run(
+      `INSERT INTO tournament_signups (
+         signup_type,
+         player_handle,
+         email,
+         region,
+         role_preference,
+         availability,
+         team_name,
+         captain_name,
+         captain_email,
+         team_size,
+         time_slot,
+         contact_handle
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        type,
+        playerHandle ?? null,
+        email ?? null,
+        region ?? null,
+        rolePreference ?? null,
+        availability ?? null,
+        teamName ?? null,
+        captainName ?? null,
+        captainEmail ?? null,
+        teamSize ?? null,
+        timeSlot ?? null,
+        contactHandle ?? null,
+      ]
+    );
+
+    return reply.code(201).send({ id: result.lastID });
+  });
+};

--- a/signup.html
+++ b/signup.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Arcadia Clash is a competitive tournament hub for managing brackets, teams, and live matches." />
+    <meta property="og:title" content="Arcadia Clash - Tournament Hub" />
+    <meta property="og:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://arcadiaclash.gg/" />
+    <meta property="og:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Arcadia Clash - Tournament Hub" />
+    <meta name="twitter:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta name="twitter:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <title>Arcadia Clash - Splatoon 3 Sign Up</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ARCADIA-0001"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-ARCADIA-0001");
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav">
+        <a class="logo" href="index.html">
+          <span class="logo-mark">AC</span>
+          <span class="logo-text">Arcadia Clash</span>
+        </a>
+        <div class="nav-links">
+          <a href="index.html#features">Features</a>
+          <a href="index.html#brackets">Brackets</a>
+          <a href="index.html#schedule">Schedule</a>
+          <a href="index.html#community">Community</a>
+          <a href="signup.html" class="active">Sign Up</a>
+          <a href="user-signup.html">User Sign Up</a>
+          <a href="schedule.html">Schedule List</a>
+          <a href="faq.html">FAQ</a>
+          <a href="team-management.html">Team Management</a>
+          <a href="player-dashboard.html">Player Dashboard</a>
+          <a href="player-profile.html">Player Profile</a>
+          <a href="team-profile.html">Team Profile</a>
+          <a href="match-center.html">Match Center</a>
+          <a href="event-detail.html">Event Detail</a>
+          <a href="tickets.html">Tickets</a>
+          <a href="support.html">Support</a>
+          <a href="rules.html">Rules</a>
+          <a href="standings.html">Standings</a>
+          <a href="admin-console.html">Admin Console</a>
+          <a href="seeding.html">Seeding</a>
+        </div>
+        <div class="auth-status" data-auth-status>
+          <a class="btn ghost" href="login.html" data-auth-signin>Sign In</a>
+          <div class="auth-user is-hidden" data-auth-user></div>
+          <button class="btn ghost is-hidden" type="button" data-auth-logout>Sign Out</button>
+        </div>
+      </nav>
+    </header>
+
+    <main class="signup">
+      <section class="signup-hero">
+        <p class="tag">Splatoon 3 • Open Registration</p>
+        <h1>Join the Splatoon 3 Turf War Showdown.</h1>
+        <p class="subhead">
+          Register as a solo competitor or lock in your squad. We will match individual players into
+          balanced teams and confirm brackets within 48 hours of registration closing.
+        </p>
+        <div class="signup-details">
+          <div>
+            <h3>April 20 - 22</h3>
+            <p>Online qualifiers · Finals on April 28</p>
+          </div>
+          <div>
+            <h3>$5,000 Prize Pool</h3>
+            <p>Cash, gear, and sponsor bundles</p>
+          </div>
+          <div>
+            <h3>All Regions</h3>
+            <p>Custom time slots for NA, EU, and APAC</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="signup-forms">
+        <div class="form-card">
+          <h2>Individual player sign up</h2>
+          <p class="form-note">Ideal for free agents and solo entrants.</p>
+          <form id="individual-signup-form">
+            <label>
+              Player handle
+              <input type="text" name="playerHandle" placeholder="InkStorm" required />
+            </label>
+            <label>
+              Email address
+              <input type="email" name="email" placeholder="you@email.com" required />
+            </label>
+            <label>
+              Region
+              <select name="region" required>
+                <option value="">Select region</option>
+                <option>North America</option>
+                <option>Europe</option>
+                <option>Asia Pacific</option>
+                <option>South America</option>
+              </select>
+            </label>
+            <label>
+              Role preference
+              <select name="rolePreference" required>
+                <option value="">Select role</option>
+                <option>Slayer</option>
+                <option>Support</option>
+                <option>Anchor</option>
+                <option>Flex</option>
+              </select>
+            </label>
+            <label>
+              Availability
+              <input type="text" name="availability" placeholder="Weekends after 5pm" required />
+            </label>
+            <label class="checkbox">
+              <input type="checkbox" required />
+              I agree to the tournament rules and code of conduct.
+            </label>
+            <button class="btn primary full" type="submit">Reserve my spot</button>
+            <p id="individual-signup-status" class="helper-text" role="status"></p>
+          </form>
+        </div>
+
+        <div class="form-card">
+          <h2>Team sign up</h2>
+          <p class="form-note">For squads ready to compete together.</p>
+          <form id="team-signup-form">
+            <label>
+              Team name
+              <input type="text" name="teamName" placeholder="Neon Nautilus" required />
+            </label>
+            <label>
+              Captain name
+              <input type="text" name="captainName" placeholder="Alex Rivera" required />
+            </label>
+            <label>
+              Captain email
+              <input type="email" name="captainEmail" placeholder="captain@email.com" required />
+            </label>
+            <label>
+              Team size
+              <select name="teamSize" required>
+                <option value="">Select size</option>
+                <option>4 starters</option>
+                <option>4 + 1 substitute</option>
+                <option>4 + 2 substitutes</option>
+              </select>
+            </label>
+            <label>
+              Preferred time slot
+              <select name="timeSlot" required>
+                <option value="">Select time slot</option>
+                <option>NA Evening</option>
+                <option>EU Prime</option>
+                <option>APAC Night</option>
+              </select>
+            </label>
+            <label>
+              Team contact handle
+              <input type="text" name="contactHandle" placeholder="@neonnautilus" required />
+            </label>
+            <label class="checkbox">
+              <input type="checkbox" required />
+              We agree to the tournament rules and roster lock policy.
+            </label>
+            <button class="btn primary full" type="submit">Register team</button>
+            <p id="team-signup-status" class="helper-text" role="status"></p>
+          </form>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div>
+        <h3>Need help with registration?</h3>
+        <p>Email support@arcadiaclash.gg or join the Discord for instant assistance.</p>
+      </div>
+      <button class="btn secondary">Join Discord</button>
+    </footer>
+    <script src="auth.js"></script>
+    <script src="signup.js"></script>
+  </body>
+</html>

--- a/signup.js
+++ b/signup.js
@@ -1,0 +1,78 @@
+const individualForm = document.querySelector('#individual-signup-form');
+const teamForm = document.querySelector('#team-signup-form');
+const individualStatus = document.querySelector('#individual-signup-status');
+const teamStatus = document.querySelector('#team-signup-status');
+
+const setStatus = (element, message, type = 'info') => {
+  if (!element) {
+    return;
+  }
+  element.textContent = message;
+  if (type === 'error' || type === 'success') {
+    element.dataset.status = type;
+  } else {
+    element.removeAttribute('data-status');
+  }
+};
+
+const submitSignup = async (payload) => {
+  const response = await fetch('/api/tournament-signups', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error?.error ?? 'Unable to submit signup.');
+  }
+
+  return response.json();
+};
+
+if (individualForm) {
+  individualForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const formData = new FormData(individualForm);
+    const payload = {
+      type: 'individual',
+      playerHandle: formData.get('playerHandle')?.toString().trim(),
+      email: formData.get('email')?.toString().trim(),
+      region: formData.get('region')?.toString().trim(),
+      rolePreference: formData.get('rolePreference')?.toString().trim(),
+      availability: formData.get('availability')?.toString().trim(),
+    };
+
+    try {
+      await submitSignup(payload);
+      individualForm.reset();
+      setStatus(individualStatus, 'Registration submitted. We will confirm by email.', 'success');
+    } catch (error) {
+      setStatus(individualStatus, error.message, 'error');
+    }
+  });
+}
+
+if (teamForm) {
+  teamForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const formData = new FormData(teamForm);
+    const payload = {
+      type: 'team',
+      teamName: formData.get('teamName')?.toString().trim(),
+      captainName: formData.get('captainName')?.toString().trim(),
+      captainEmail: formData.get('captainEmail')?.toString().trim(),
+      teamSize: formData.get('teamSize')?.toString().trim(),
+      timeSlot: formData.get('timeSlot')?.toString().trim(),
+      contactHandle: formData.get('contactHandle')?.toString().trim(),
+    };
+
+    try {
+      await submitSignup(payload);
+      teamForm.reset();
+      setStatus(teamStatus, 'Team registration received. We will follow up soon.', 'success');
+    } catch (error) {
+      setStatus(teamStatus, error.message, 'error');
+    }
+  });
+}

--- a/standings.html
+++ b/standings.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Arcadia Clash is a competitive tournament hub for managing brackets, teams, and live matches." />
+    <meta property="og:title" content="Arcadia Clash - Tournament Hub" />
+    <meta property="og:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://arcadiaclash.gg/" />
+    <meta property="og:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Arcadia Clash - Tournament Hub" />
+    <meta name="twitter:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta name="twitter:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <title>Arcadia Clash - Standings</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ARCADIA-0001"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-ARCADIA-0001");
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav">
+        <a class="logo" href="index.html">
+          <span class="logo-mark">AC</span>
+          <span class="logo-text">Arcadia Clash</span>
+        </a>
+        <div class="nav-links">
+          <a href="index.html#features">Features</a>
+          <a href="index.html#brackets">Brackets</a>
+          <a href="index.html#schedule">Schedule</a>
+          <a href="index.html#community">Community</a>
+          <a href="signup.html">Tournament Sign Up</a>
+          <a href="user-signup.html">User Sign Up</a>
+          <a href="schedule.html">Schedule List</a>
+          <a href="team-management.html">Team Management</a>
+          <a href="player-dashboard.html">Player Dashboard</a>
+          <a href="match-center.html">Match Center</a>
+          <a href="player-profile.html">Player Profile</a>
+          <a href="team-profile.html">Team Profile</a>
+          <a href="event-detail.html">Event Detail</a>
+          <a href="tickets.html">Tickets</a>
+          <a href="support.html">Support</a>
+          <a href="rules.html">Rules</a>
+          <a href="standings.html" class="active">Standings</a>
+          <a href="admin-console.html">Admin Console</a>
+          <a href="seeding.html">Seeding</a>
+          <a href="faq.html">FAQ</a>
+        </div>
+        <div class="auth-status" data-auth-status>
+          <a class="btn ghost" href="login.html" data-auth-signin>Sign In</a>
+          <div class="auth-user is-hidden" data-auth-user></div>
+          <button class="btn ghost is-hidden" type="button" data-auth-logout>Sign Out</button>
+        </div>
+      </nav>
+    </header>
+
+    <main class="standings">
+      <section class="standings-hero">
+        <div>
+          <p class="tag">Splatoon 3 • Season Leaderboard</p>
+          <h1>Standings & Leaderboard</h1>
+          <p class="subhead">
+            Track rankings, seed points, and performance trends as teams climb toward the finals.
+          </p>
+        </div>
+        <div class="standings-actions">
+          <button class="btn secondary">Filter by region</button>
+          <button class="btn ghost">Export CSV</button>
+        </div>
+      </section>
+
+      <section class="standings-table">
+        <div class="standings-header">
+          <h2>Top 10 teams</h2>
+          <div class="standings-meta" id="standings-meta">Updated moments ago</div>
+        </div>
+        <p id="standings-status" class="helper-text" role="status"></p>
+        <div class="table-row header">
+          <span>Rank</span>
+          <span>Team</span>
+          <span>Record</span>
+          <span>Seed Points</span>
+          <span>Streak</span>
+        </div>
+        <div id="standings-rows"></div>
+      </section>
+
+      <section class="standings-insights">
+        <div>
+          <h2>Performance insights</h2>
+          <p>Identify breakout teams and watch for streaks heading into playoffs.</p>
+        </div>
+        <div class="insight-grid">
+          <div>
+            <h3>Best offense</h3>
+            <p>Crimson Circuit · 68% map control</p>
+          </div>
+          <div>
+            <h3>Fast riser</h3>
+            <p>Solar Splatter · +4 positions</p>
+          </div>
+          <div>
+            <h3>Most improved</h3>
+            <p>Echo Flux · +210 points</p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div>
+        <h3>Want the full leaderboard?</h3>
+        <p>Download the standings to share with your community.</p>
+      </div>
+      <button class="btn primary">Download standings</button>
+    </footer>
+    <script src="auth.js"></script>
+    <script src="standings.js"></script>
+  </body>
+</html>

--- a/standings.js
+++ b/standings.js
@@ -1,0 +1,109 @@
+const standingsRows = document.querySelector('#standings-rows');
+const standingsStatus = document.querySelector('#standings-status');
+const standingsMeta = document.querySelector('#standings-meta');
+
+const setStatus = (message, type = 'info') => {
+  if (!standingsStatus) {
+    return;
+  }
+  standingsStatus.textContent = message;
+  if (type === 'error' || type === 'success') {
+    standingsStatus.dataset.status = type;
+  } else {
+    standingsStatus.removeAttribute('data-status');
+  }
+};
+
+const trendClass = (streak) => {
+  if (!streak) {
+    return 'trend';
+  }
+  if (streak.startsWith('W')) {
+    return 'trend up';
+  }
+  if (streak.startsWith('L')) {
+    return 'trend down';
+  }
+  return 'trend';
+};
+
+const POLL_INTERVAL_MS = 15000;
+let pollHandle;
+
+const loadStandings = async () => {
+  if (!standingsRows) {
+    return;
+  }
+
+  const response = await fetch('/api/standings');
+  if (!response.ok) {
+    setStatus('Standings are unavailable right now.', 'error');
+    return;
+  }
+
+  const rows = await response.json();
+  if (!Array.isArray(rows) || rows.length === 0) {
+    standingsRows.innerHTML = `
+      <div class="table-row">
+        <span class="rank">—</span>
+        <span>No standings data yet.</span>
+        <span>—</span>
+        <span>—</span>
+        <span class="trend">—</span>
+      </div>
+    `;
+    setStatus('Waiting for standings updates.', 'info');
+    return;
+  }
+
+  standingsRows.innerHTML = rows
+    .slice(0, 10)
+    .map((row, index) => {
+      const record = `${row.wins}-${row.losses}`;
+      const streak = row.streak ?? '—';
+      return `
+        <div class="table-row">
+          <span class="rank">#${index + 1}</span>
+          <span>${row.team_name}</span>
+          <span>${record}</span>
+          <span>${row.seed_points}</span>
+          <span class="${trendClass(streak)}">${streak}</span>
+        </div>
+      `;
+    })
+    .join('');
+
+  if (standingsMeta) {
+    standingsMeta.textContent = `Updated ${new Date().toLocaleTimeString()}`;
+  }
+  setStatus('Live standings loaded.', 'success');
+};
+
+const startPolling = () => {
+  if (pollHandle) {
+    return;
+  }
+  pollHandle = window.setInterval(() => {
+    loadStandings();
+  }, POLL_INTERVAL_MS);
+};
+
+const stopPolling = () => {
+  if (!pollHandle) {
+    return;
+  }
+  window.clearInterval(pollHandle);
+  pollHandle = null;
+};
+
+loadStandings();
+startPolling();
+
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden) {
+    stopPolling();
+  } else {
+    loadStandings();
+    startPolling();
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,1502 @@
+:root {
+  color-scheme: dark;
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+  background-color: #05070f;
+  color: #e6e9f5;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: radial-gradient(circle at top, #182044, #05070f 60%);
+  min-height: 100vh;
+}
+
+a {
+  text-decoration: none;
+  color: inherit;
+}
+
+button {
+  font-family: inherit;
+}
+
+.site-header {
+  padding: 24px 6vw;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 700;
+}
+
+.logo-mark {
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #7a7dff, #38f9d7);
+  color: #05070f;
+}
+
+.nav-links {
+  display: flex;
+  gap: 20px;
+  color: #b9bed6;
+  font-size: 0.95rem;
+}
+
+.nav-links a.active {
+  color: #38f9d7;
+  font-weight: 600;
+  border-bottom: 2px solid rgba(56, 249, 215, 0.6);
+  padding-bottom: 2px;
+}
+
+.btn {
+  border: none;
+  padding: 12px 22px;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, #7a7dff, #38f9d7);
+  color: #05070f;
+}
+
+.btn.secondary {
+  background: rgba(122, 125, 255, 0.2);
+  color: #e6e9f5;
+  border: 1px solid rgba(122, 125, 255, 0.5);
+}
+
+.btn.ghost {
+  background: transparent;
+  border: 1px solid rgba(230, 233, 245, 0.25);
+  color: #e6e9f5;
+}
+
+.btn.full {
+  width: 100%;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 96px;
+  padding: 0 6vw 80px;
+}
+
+.signup {
+  gap: 64px;
+}
+
+.auth {
+  gap: 64px;
+  align-items: center;
+}
+
+.schedule-page {
+  gap: 56px;
+}
+
+.faq {
+  gap: 64px;
+}
+
+.team-management {
+  gap: 64px;
+}
+
+.player-dashboard {
+  gap: 64px;
+}
+
+.match-center {
+  gap: 64px;
+}
+
+.rules {
+  gap: 64px;
+}
+
+.standings {
+  gap: 64px;
+}
+
+.admin-console {
+  gap: 64px;
+}
+
+.profile {
+  gap: 64px;
+}
+
+.event-detail {
+  gap: 64px;
+}
+
+.tickets {
+  gap: 64px;
+}
+
+.support {
+  gap: 64px;
+}
+
+.support-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+  align-items: center;
+  padding-top: 32px;
+}
+
+.support-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.support-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 28px;
+}
+
+.contact-list,
+.topic-list,
+.status-list {
+  display: grid;
+  gap: 12px;
+  color: #cdd2ea;
+}
+
+.escalation-steps {
+  list-style: decimal;
+  padding-left: 18px;
+  color: #b9bed6;
+  display: grid;
+  gap: 10px;
+}
+
+.tickets-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+  align-items: center;
+  padding-top: 32px;
+}
+
+.tickets-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.tickets-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 28px;
+}
+
+.venue-details,
+.seat-grid,
+.agenda-list {
+  display: grid;
+  gap: 12px;
+  color: #cdd2ea;
+}
+
+.ticket-cards {
+  display: grid;
+  gap: 16px;
+}
+
+.ticket-card {
+  border-radius: 18px;
+  padding: 18px;
+  border: 1px solid rgba(122, 125, 255, 0.15);
+  background: rgba(8, 12, 26, 0.85);
+  display: grid;
+  gap: 10px;
+}
+
+.ticket-card.highlight {
+  border-color: rgba(56, 249, 215, 0.4);
+  box-shadow: 0 20px 40px rgba(3, 5, 12, 0.35);
+}
+
+.ticket-card ul {
+  list-style: none;
+  color: #b9bed6;
+  display: grid;
+  gap: 6px;
+  font-size: 0.95rem;
+}
+
+.price {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #38f9d7;
+}
+
+.event-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+  align-items: center;
+  padding-top: 32px;
+}
+
+.event-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.event-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 28px;
+}
+
+.overview-grid,
+.stream-list,
+.event-schedule {
+  display: grid;
+  gap: 12px;
+  color: #cdd2ea;
+}
+
+.rules-list {
+  list-style: none;
+  display: grid;
+  gap: 10px;
+  color: #b9bed6;
+}
+
+.profile-hero {
+  display: grid;
+  gap: 24px;
+}
+
+.profile-card {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 20px;
+  align-items: center;
+  padding: 24px;
+  border-radius: 22px;
+  background: rgba(13, 18, 36, 0.75);
+  border: 1px solid rgba(122, 125, 255, 0.15);
+}
+
+.profile-avatar {
+  width: 72px;
+  height: 72px;
+  border-radius: 20px;
+  display: grid;
+  place-items: center;
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #05070f;
+  background: linear-gradient(135deg, #7a7dff, #38f9d7);
+}
+
+.profile-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.profile-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 16px;
+  color: #cdd2ea;
+}
+
+.profile-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 28px;
+}
+
+.history-list {
+  display: grid;
+  gap: 12px;
+  color: #b9bed6;
+}
+
+.loadout-grid,
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+  color: #cdd2ea;
+}
+
+.admin-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+  align-items: center;
+  padding-top: 32px;
+}
+
+.admin-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.admin-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 28px;
+}
+
+.approval-list {
+  display: grid;
+  gap: 12px;
+}
+
+.approval-card {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px;
+  border-radius: 14px;
+  background: rgba(8, 12, 26, 0.85);
+  border: 1px solid rgba(122, 125, 255, 0.12);
+}
+
+.approval-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.checklist {
+  list-style: none;
+  display: grid;
+  gap: 10px;
+  color: #b9bed6;
+}
+
+.checklist li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.control-grid {
+  display: grid;
+  gap: 12px;
+  color: #cdd2ea;
+}
+
+.incident-list {
+  display: grid;
+  gap: 12px;
+  color: #b9bed6;
+}
+
+.standings-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+  align-items: center;
+  padding-top: 32px;
+}
+
+.standings-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.standings-table {
+  display: grid;
+  gap: 12px;
+}
+
+.standings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.standings-meta {
+  font-size: 0.85rem;
+  color: #b9bed6;
+}
+
+.table-row {
+  display: grid;
+  grid-template-columns: 0.6fr 2fr 1fr 1fr 0.8fr;
+  gap: 12px;
+  align-items: center;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: rgba(8, 12, 26, 0.85);
+  border: 1px solid rgba(122, 125, 255, 0.12);
+  color: #cdd2ea;
+}
+
+.table-row.header {
+  background: rgba(13, 18, 36, 0.75);
+  font-weight: 600;
+  color: #e6e9f5;
+}
+
+.rank {
+  color: #38f9d7;
+  font-weight: 700;
+}
+
+.trend {
+  font-weight: 600;
+  color: #cdd2ea;
+}
+
+.trend.up {
+  color: #38f9d7;
+}
+
+.trend.down {
+  color: #ff6384;
+}
+
+.standings-insights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+  align-items: center;
+}
+
+.insight-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+  color: #b9bed6;
+}
+
+.rules-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+  align-items: center;
+  padding-top: 32px;
+}
+
+.rules-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.rules-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 18px;
+}
+
+.rules-card {
+  background: rgba(13, 18, 36, 0.7);
+  border: 1px solid rgba(122, 125, 255, 0.12);
+  border-radius: 18px;
+  padding: 20px;
+  display: grid;
+  gap: 12px;
+}
+
+.rules-card ul {
+  list-style: none;
+  color: #b9bed6;
+  display: grid;
+  gap: 8px;
+  font-size: 0.95rem;
+}
+
+.rules-callout {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 24px;
+  border-radius: 20px;
+  border: 1px solid rgba(122, 125, 255, 0.2);
+  background: linear-gradient(135deg, rgba(122, 125, 255, 0.15), rgba(56, 249, 215, 0.1));
+}
+
+.match-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+  align-items: center;
+  padding-top: 32px;
+}
+
+.match-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.match-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 28px;
+}
+
+.scoreboard {
+  display: grid;
+  gap: 16px;
+}
+
+.team-score {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 14px;
+  border-radius: 16px;
+  background: rgba(8, 12, 26, 0.85);
+  border: 1px solid rgba(122, 125, 255, 0.12);
+}
+
+.team-info {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.score {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #38f9d7;
+}
+
+.map-list {
+  display: grid;
+  gap: 10px;
+  color: #b9bed6;
+}
+
+.timeline {
+  display: grid;
+  gap: 10px;
+  color: #b9bed6;
+}
+
+.timeline ul {
+  list-style: none;
+  display: grid;
+  gap: 6px;
+  font-size: 0.92rem;
+}
+
+.highlight-list {
+  display: grid;
+  gap: 12px;
+}
+
+.chat-box {
+  background: rgba(8, 12, 26, 0.85);
+  border: 1px solid rgba(122, 125, 255, 0.12);
+  border-radius: 16px;
+  padding: 16px;
+  display: grid;
+  gap: 8px;
+  color: #b9bed6;
+}
+
+.dashboard-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+  align-items: center;
+  padding-top: 32px;
+}
+
+.dashboard-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 28px;
+}
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 16px;
+  color: #cdd2ea;
+}
+
+.stat-grid h3 {
+  font-size: 1.5rem;
+  margin-bottom: 4px;
+}
+
+.progress-card {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 16px;
+  background: rgba(8, 12, 26, 0.8);
+  border: 1px solid rgba(122, 125, 255, 0.12);
+  color: #b9bed6;
+}
+
+.progress-bar {
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(122, 125, 255, 0.2);
+  overflow: hidden;
+}
+
+.progress-bar span {
+  display: block;
+  height: 100%;
+  background: linear-gradient(135deg, #7a7dff, #38f9d7);
+}
+
+.match-list {
+  display: grid;
+  gap: 12px;
+  color: #cdd2ea;
+}
+
+.invite-list {
+  display: grid;
+  gap: 12px;
+}
+
+.invite-card {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px;
+  border-radius: 14px;
+  background: rgba(8, 12, 26, 0.85);
+  border: 1px solid rgba(122, 125, 255, 0.12);
+}
+
+.invite-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.highlight-card {
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+  border-radius: 16px;
+  background: rgba(8, 12, 26, 0.85);
+  border: 1px solid rgba(122, 125, 255, 0.12);
+}
+
+.highlight-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+  color: #b9bed6;
+}
+
+.team-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+  align-items: center;
+  padding-top: 32px;
+}
+
+.team-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.team-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 28px;
+}
+
+.roster-list {
+  display: grid;
+  gap: 14px;
+}
+
+.roster-card {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 14px;
+  border-radius: 16px;
+  background: rgba(8, 12, 26, 0.85);
+  border: 1px solid rgba(122, 125, 255, 0.12);
+}
+
+.avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  color: #05070f;
+  background: linear-gradient(135deg, #7a7dff, #38f9d7);
+}
+
+.readiness-grid {
+  display: grid;
+  gap: 16px;
+  color: #cdd2ea;
+}
+
+.readiness-grid h3 {
+  margin-bottom: 6px;
+}
+
+.readiness-card {
+  background: rgba(8, 12, 26, 0.8);
+  border-radius: 16px;
+  padding: 16px;
+  border: 1px solid rgba(122, 125, 255, 0.12);
+  display: grid;
+  gap: 12px;
+}
+
+.readiness-card ul {
+  list-style: none;
+  color: #b9bed6;
+  display: grid;
+  gap: 6px;
+  font-size: 0.92rem;
+}
+
+.team-notes {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+  align-items: center;
+}
+
+.notes-card {
+  background: rgba(13, 18, 36, 0.7);
+  border: 1px solid rgba(122, 125, 255, 0.12);
+  border-radius: 18px;
+  padding: 20px;
+  display: grid;
+  gap: 12px;
+  color: #b9bed6;
+}
+
+.faq-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+  align-items: center;
+  padding-top: 32px;
+}
+
+.faq-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.faq-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 18px;
+}
+
+.faq-card {
+  background: rgba(13, 18, 36, 0.7);
+  border: 1px solid rgba(122, 125, 255, 0.12);
+  border-radius: 18px;
+  padding: 20px;
+  display: grid;
+  gap: 10px;
+}
+
+.faq-card h2 {
+  font-size: 1.1rem;
+}
+
+.faq-card p {
+  color: #b9bed6;
+}
+
+.faq-callout {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 24px;
+  border-radius: 20px;
+  border: 1px solid rgba(122, 125, 255, 0.2);
+  background: linear-gradient(135deg, rgba(122, 125, 255, 0.15), rgba(56, 249, 215, 0.1));
+}
+
+.schedule-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+  align-items: center;
+  padding-top: 32px;
+}
+
+.schedule-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.schedule-list {
+  display: grid;
+  gap: 16px;
+}
+
+.schedule-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 160px) 1fr auto;
+  gap: 20px;
+  align-items: center;
+  padding: 18px 20px;
+  border-radius: 18px;
+  background: rgba(13, 18, 36, 0.7);
+  border: 1px solid rgba(122, 125, 255, 0.12);
+}
+
+.schedule-date {
+  display: grid;
+  gap: 6px;
+  color: #cdd2ea;
+}
+
+.schedule-date .day {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.schedule-date .time {
+  font-size: 0.85rem;
+  color: #7f86a9;
+}
+
+.schedule-info h2 {
+  font-size: 1.2rem;
+  margin-bottom: 6px;
+}
+
+.schedule-info p {
+  color: #b9bed6;
+}
+
+.schedule-meta {
+  display: grid;
+  justify-items: end;
+  gap: 10px;
+}
+
+.status-pill {
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  background: rgba(122, 125, 255, 0.2);
+  color: #cdd2ea;
+}
+
+.status-pill.open {
+  background: rgba(56, 249, 215, 0.2);
+  color: #38f9d7;
+}
+
+.auth-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.auth-user {
+  font-size: 0.85rem;
+  color: #cdd2ea;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(122, 125, 255, 0.15);
+}
+
+.is-hidden {
+  display: none !important;
+}
+
+.auth-hero {
+  text-align: center;
+  max-width: 680px;
+}
+
+.auth-card {
+  width: min(720px, 100%);
+  background: rgba(13, 18, 36, 0.75);
+  border: 1px solid rgba(122, 125, 255, 0.15);
+  border-radius: 22px;
+  padding: 28px;
+  display: grid;
+  gap: 18px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+}
+
+.seeding {
+  gap: 64px;
+}
+
+.seeding-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+  align-items: center;
+  padding-top: 32px;
+}
+
+.seeding-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.seeding-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 28px;
+}
+
+.panel {
+  background: rgba(13, 18, 36, 0.7);
+  border: 1px solid rgba(122, 125, 255, 0.15);
+  border-radius: 20px;
+  padding: 24px;
+  display: grid;
+  gap: 20px;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.seed-list {
+  list-style: none;
+  display: grid;
+  gap: 14px;
+}
+
+.seed-list li {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 14px;
+  align-items: center;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: rgba(8, 12, 26, 0.85);
+  border: 1px solid rgba(122, 125, 255, 0.12);
+}
+
+.seed {
+  font-weight: 700;
+  color: #38f9d7;
+}
+
+.status {
+  font-size: 0.75rem;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(122, 125, 255, 0.2);
+  color: #cdd2ea;
+}
+
+.status.locked {
+  background: rgba(56, 249, 215, 0.2);
+  color: #38f9d7;
+}
+
+.bracket-preview {
+  display: grid;
+  gap: 18px;
+}
+
+.bracket-round {
+  background: rgba(8, 12, 26, 0.8);
+  border-radius: 16px;
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+  border: 1px solid rgba(122, 125, 255, 0.12);
+}
+
+.bracket-round h3 {
+  font-size: 1rem;
+}
+
+.match {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  color: #e6e9f5;
+  font-size: 0.9rem;
+}
+
+.match.dim {
+  color: #8f95b8;
+}
+
+.seeding-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 16px;
+  color: #b9bed6;
+}
+
+.seeding-summary h4 {
+  margin-bottom: 6px;
+  font-size: 0.95rem;
+}
+
+.signup-hero {
+  display: grid;
+  gap: 24px;
+  padding-top: 32px;
+}
+
+.signup-details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 18px;
+  color: #cdd2ea;
+}
+
+.signup-details h3 {
+  font-size: 1.4rem;
+  margin-bottom: 6px;
+}
+
+.signup-forms {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 28px;
+}
+
+.form-card {
+  background: rgba(13, 18, 36, 0.7);
+  border: 1px solid rgba(122, 125, 255, 0.15);
+  border-radius: 20px;
+  padding: 24px;
+  display: grid;
+  gap: 18px;
+}
+
+.form-card form {
+  display: grid;
+  gap: 14px;
+}
+
+.form-note {
+  color: #b9bed6;
+}
+
+label {
+  display: grid;
+  gap: 6px;
+  font-size: 0.95rem;
+}
+
+input,
+select {
+  background: rgba(8, 12, 26, 0.9);
+  border: 1px solid rgba(122, 125, 255, 0.25);
+  border-radius: 10px;
+  padding: 10px 12px;
+  color: #e6e9f5;
+  font-size: 0.95rem;
+}
+
+input::placeholder {
+  color: #7f86a9;
+}
+
+.checkbox {
+  grid-auto-flow: column;
+  justify-content: start;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.9rem;
+  color: #b9bed6;
+}
+
+.checkbox input {
+  width: 16px;
+  height: 16px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 36px;
+  align-items: center;
+  padding-top: 32px;
+}
+
+.hero-content h1 {
+  font-size: clamp(2.2rem, 4vw, 3.5rem);
+  line-height: 1.1;
+  margin-bottom: 18px;
+}
+
+.subhead {
+  color: #b9bed6;
+  font-size: 1.05rem;
+  margin-bottom: 24px;
+}
+
+.tag {
+  display: inline-flex;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(56, 249, 215, 0.15);
+  color: #38f9d7;
+  font-size: 0.85rem;
+  margin-bottom: 16px;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 28px;
+}
+
+.hero-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 18px;
+  color: #cdd2ea;
+}
+
+.hero-stats h3 {
+  font-size: 1.6rem;
+  margin-bottom: 4px;
+}
+
+.hero-card {
+  background: rgba(13, 18, 36, 0.85);
+  border-radius: 24px;
+  padding: 28px;
+  border: 1px solid rgba(122, 125, 255, 0.2);
+  box-shadow: 0 20px 40px rgba(3, 5, 12, 0.4);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 18px;
+}
+
+.pill {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(255, 99, 132, 0.2);
+  color: #ff6384;
+  font-size: 0.75rem;
+}
+
+.stacked-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.field {
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  color: #9aa3c7;
+}
+
+.field input,
+.field textarea {
+  background: rgba(13, 18, 36, 0.75);
+  border: 1px solid rgba(122, 125, 255, 0.2);
+  border-radius: 12px;
+  padding: 0.75rem 0.9rem;
+  color: #f7f7fb;
+  font-family: inherit;
+  font-size: 0.95rem;
+}
+
+.field input:focus,
+.field textarea:focus {
+  outline: 2px solid rgba(122, 125, 255, 0.5);
+  border-color: transparent;
+}
+
+.helper-text {
+  min-height: 1.2rem;
+  font-size: 0.85rem;
+  color: #9aa3c7;
+}
+
+.helper-text[data-status='error'] {
+  color: #ff8a8a;
+}
+
+.helper-text[data-status='success'] {
+  color: #7cf4b2;
+}
+
+.matchup {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 12px;
+  padding: 18px 0;
+  border-top: 1px solid rgba(122, 125, 255, 0.2);
+  border-bottom: 1px solid rgba(122, 125, 255, 0.2);
+}
+
+.team-name {
+  font-weight: 600;
+}
+
+.team-rank {
+  color: #7a7dff;
+  font-size: 0.85rem;
+}
+
+.vs {
+  color: #38f9d7;
+  font-weight: 700;
+}
+
+.match-info {
+  display: flex;
+  justify-content: space-between;
+  margin: 16px 0 20px;
+  color: #b9bed6;
+  font-size: 0.9rem;
+}
+
+.stream-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  margin-bottom: 16px;
+  border-radius: 12px;
+  background: rgba(145, 70, 255, 0.18);
+  color: #e6e9f5;
+  font-weight: 600;
+  border: 1px solid rgba(145, 70, 255, 0.4);
+}
+
+.stream-link:hover {
+  box-shadow: 0 12px 20px rgba(6, 8, 20, 0.4);
+}
+
+.stream-icon {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  background: rgba(145, 70, 255, 0.4);
+}
+
+.stream-icon svg {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
+}
+
+.features h2,
+.brackets h2,
+.schedule h2,
+.community h2 {
+  font-size: 2rem;
+  margin-bottom: 24px;
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 24px;
+}
+
+.feature-grid article,
+.schedule-card,
+.community-panel {
+  background: rgba(13, 18, 36, 0.7);
+  padding: 20px;
+  border-radius: 18px;
+  border: 1px solid rgba(122, 125, 255, 0.12);
+}
+
+.feature-grid h3,
+.schedule-card h3 {
+  margin-bottom: 12px;
+}
+
+.brackets {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 32px;
+  align-items: center;
+}
+
+.bracket-card {
+  display: grid;
+  gap: 16px;
+}
+
+.round {
+  background: rgba(13, 18, 36, 0.65);
+  padding: 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(122, 125, 255, 0.12);
+}
+
+.round h4 {
+  margin-bottom: 8px;
+}
+
+.round ul {
+  list-style: none;
+  color: #b9bed6;
+  display: grid;
+  gap: 6px;
+  font-size: 0.92rem;
+}
+
+.schedule {
+  display: grid;
+  gap: 24px;
+}
+
+.schedule-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.schedule-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+}
+
+.date {
+  color: #38f9d7;
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+
+.community {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+  align-items: center;
+}
+
+.community-panel {
+  display: grid;
+  gap: 16px;
+}
+
+.footer {
+  margin: 60px 6vw 30px;
+  padding: 30px;
+  border-radius: 22px;
+  background: linear-gradient(135deg, rgba(122, 125, 255, 0.2), rgba(56, 249, 215, 0.15));
+  border: 1px solid rgba(122, 125, 255, 0.25);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+@media (max-width: 720px) {
+  .nav {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .nav-links {
+    flex-wrap: wrap;
+  }
+
+  .match-info {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .schedule-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .schedule-row {
+    grid-template-columns: 1fr;
+    text-align: left;
+  }
+
+  .schedule-meta {
+    justify-items: start;
+  }
+}

--- a/support.html
+++ b/support.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Arcadia Clash is a competitive tournament hub for managing brackets, teams, and live matches." />
+    <meta property="og:title" content="Arcadia Clash - Tournament Hub" />
+    <meta property="og:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://arcadiaclash.gg/" />
+    <meta property="og:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Arcadia Clash - Tournament Hub" />
+    <meta name="twitter:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta name="twitter:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <title>Arcadia Clash - Support</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ARCADIA-0001"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-ARCADIA-0001");
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav">
+        <a class="logo" href="index.html">
+          <span class="logo-mark">AC</span>
+          <span class="logo-text">Arcadia Clash</span>
+        </a>
+        <div class="nav-links">
+          <a href="index.html#features">Features</a>
+          <a href="index.html#brackets">Brackets</a>
+          <a href="index.html#schedule">Schedule</a>
+          <a href="index.html#community">Community</a>
+          <a href="signup.html">Tournament Sign Up</a>
+          <a href="user-signup.html">User Sign Up</a>
+          <a href="schedule.html">Schedule List</a>
+          <a href="team-management.html">Team Management</a>
+          <a href="player-dashboard.html">Player Dashboard</a>
+          <a href="player-profile.html">Player Profile</a>
+          <a href="team-profile.html">Team Profile</a>
+          <a href="match-center.html">Match Center</a>
+          <a href="event-detail.html">Event Detail</a>
+          <a href="tickets.html">Tickets</a>
+          <a href="support.html" class="active">Support</a>
+          <a href="rules.html">Rules</a>
+          <a href="standings.html">Standings</a>
+          <a href="admin-console.html">Admin Console</a>
+          <a href="seeding.html">Seeding</a>
+          <a href="faq.html">FAQ</a>
+        </div>
+        <div class="auth-status" data-auth-status>
+          <a class="btn ghost" href="login.html" data-auth-signin>Sign In</a>
+          <div class="auth-user is-hidden" data-auth-user></div>
+          <button class="btn ghost is-hidden" type="button" data-auth-logout>Sign Out</button>
+        </div>
+      </nav>
+    </header>
+
+    <main class="support">
+      <section class="support-hero">
+        <div>
+          <p class="tag">Help Center</p>
+          <h1>Support & Contact</h1>
+          <p class="subhead">
+            Get help fast with match issues, account requests, and event-day escalations. Our staff
+            monitor tickets and live channels throughout the tournament.
+          </p>
+        </div>
+        <div class="support-actions">
+          <button class="btn primary">Open support ticket</button>
+          <button class="btn secondary">Join live support</button>
+        </div>
+      </section>
+
+      <section class="support-grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Contact channels</h2>
+            <button class="btn ghost">Update status</button>
+          </div>
+          <div class="contact-list">
+            <div>
+              <h3>Email support</h3>
+              <p>support@arcadiaclash.gg · Response within 12 hours</p>
+            </div>
+            <div>
+              <h3>Discord helpdesk</h3>
+              <p>#support-live · 24/7 during events</p>
+            </div>
+            <div>
+              <h3>Hotline</h3>
+              <p>+1 (555) 013-8842 · Match-day emergencies</p>
+            </div>
+          </div>
+          <button class="btn secondary">Copy contact info</button>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Common support topics</h2>
+            <button class="btn ghost">Browse knowledge base</button>
+          </div>
+          <div class="topic-list">
+            <div>
+              <h3>Match disputes</h3>
+              <p>Report lag, disconnects, or rules clarifications.</p>
+            </div>
+            <div>
+              <h3>Account access</h3>
+              <p>Reset passwords, update email, or verify eligibility.</p>
+            </div>
+            <div>
+              <h3>Ticketing & refunds</h3>
+              <p>Get help with seating changes and ticket transfers.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="support-grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Escalation flow</h2>
+            <button class="btn ghost">View policy</button>
+          </div>
+          <ol class="escalation-steps">
+            <li>Submit a ticket with match ID and screenshots.</li>
+            <li>Wait for the on-duty admin to acknowledge.</li>
+            <li>If unresolved, escalate to tournament director.</li>
+            <li>Final ruling posted in the match room.</li>
+          </ol>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Live status</h2>
+            <button class="btn ghost">Refresh</button>
+          </div>
+          <div class="status-list">
+            <div>
+              <h3>Ticket queue</h3>
+              <p>4 open · Avg response 18 min</p>
+            </div>
+            <div>
+              <h3>Admin on duty</h3>
+              <p>NovaKai · Shift until 9:00 PM PT</p>
+            </div>
+            <div>
+              <h3>Current incidents</h3>
+              <p>1 active · Stream delay</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="support-grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Submit a support ticket</h2>
+            <span class="pill">API connected</span>
+          </div>
+          <form id="support-ticket-form" class="stacked-form">
+            <p class="helper-text">Sign in to auto-link your account to this ticket.</p>
+            <label class="field">
+              <span>Subject</span>
+              <input type="text" name="subject" required placeholder="Match dispute or ticketing" />
+            </label>
+            <label class="field">
+              <span>Message</span>
+              <textarea
+                name="message"
+                rows="4"
+                required
+                placeholder="Share match ID, screenshots, or details."
+              ></textarea>
+            </label>
+            <button class="btn primary" type="submit">Send ticket</button>
+            <p id="support-ticket-status" class="helper-text" role="status"></p>
+          </form>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>My profile snapshot</h2>
+            <button id="profile-refresh" class="btn ghost" type="button">Load profile</button>
+          </div>
+          <div id="profile-summary" class="status-list">
+            <div>
+              <h3>Status</h3>
+              <p>Sign in to view account details.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div>
+        <h3>Need urgent help?</h3>
+        <p>Use the emergency hotline during live matches.</p>
+      </div>
+      <button class="btn primary">Call hotline</button>
+    </footer>
+    <script src="auth.js"></script>
+    <script src="support.js"></script>
+  </body>
+</html>

--- a/support.js
+++ b/support.js
@@ -1,0 +1,98 @@
+const form = document.querySelector('#support-ticket-form');
+const statusEl = document.querySelector('#support-ticket-status');
+const profileButton = document.querySelector('#profile-refresh');
+const profileSummary = document.querySelector('#profile-summary');
+const authClient = window.ArcadiaAuth;
+
+const setStatus = (message, type = 'info') => {
+  if (!statusEl) {
+    return;
+  }
+  statusEl.textContent = message;
+  if (type === 'error' || type === 'success') {
+    statusEl.dataset.status = type;
+  } else {
+    statusEl.removeAttribute('data-status');
+  }
+};
+
+const updateProfileSummary = (user) => {
+  if (!profileSummary) {
+    return;
+  }
+  if (!user) {
+    profileSummary.innerHTML = `
+      <div>
+        <h3>Status</h3>
+        <p>Sign in to view account details.</p>
+      </div>
+    `;
+    return;
+  }
+  profileSummary.innerHTML = `
+    <div>
+      <h3>Signed in as</h3>
+      <p>${user.displayName} · ${user.email}</p>
+    </div>
+    <div>
+      <h3>Member since</h3>
+      <p>${new Date(user.created_at).toLocaleDateString()}</p>
+    </div>
+  `;
+};
+
+const fetchProfile = async () => {
+  const token = authClient?.getAccessToken();
+  if (!token) {
+    updateProfileSummary(null);
+    setStatus('Sign in to load your profile.', 'error');
+    return;
+  }
+
+  const response = await authClient.authenticatedFetch('/api/me');
+
+  if (!response.ok) {
+    updateProfileSummary(null);
+    setStatus('Unable to load profile. Please sign in again.', 'error');
+    return;
+  }
+
+  const data = await response.json();
+  updateProfileSummary(data.user);
+  setStatus('Profile loaded.', 'success');
+};
+
+if (form) {
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const token = authClient?.getAccessToken();
+    const subject = form.elements.subject?.value.trim();
+    const message = form.elements.message?.value.trim();
+
+    if (!token) {
+      setStatus('Sign in before submitting a ticket.', 'error');
+      return;
+    }
+
+    const response = await authClient.authenticatedFetch('/api/support/tickets', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ subject, message }),
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      setStatus(error?.error ?? 'Unable to submit ticket.', 'error');
+      return;
+    }
+
+    form.reset();
+    setStatus('Ticket submitted. Support will follow up shortly.', 'success');
+  });
+}
+
+if (profileButton) {
+  profileButton.addEventListener('click', fetchProfile);
+}

--- a/team-management.html
+++ b/team-management.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Arcadia Clash is a competitive tournament hub for managing brackets, teams, and live matches." />
+    <meta property="og:title" content="Arcadia Clash - Tournament Hub" />
+    <meta property="og:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://arcadiaclash.gg/" />
+    <meta property="og:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Arcadia Clash - Tournament Hub" />
+    <meta name="twitter:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta name="twitter:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <title>Arcadia Clash - Team Management</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ARCADIA-0001"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-ARCADIA-0001");
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav">
+        <a class="logo" href="index.html">
+          <span class="logo-mark">AC</span>
+          <span class="logo-text">Arcadia Clash</span>
+        </a>
+        <div class="nav-links">
+          <a href="index.html#features">Features</a>
+          <a href="index.html#brackets">Brackets</a>
+          <a href="index.html#schedule">Schedule</a>
+          <a href="index.html#community">Community</a>
+          <a href="signup.html">Tournament Sign Up</a>
+          <a href="user-signup.html">User Sign Up</a>
+          <a href="schedule.html">Schedule List</a>
+          <a href="team-management.html" class="active">Team Management</a>
+          <a href="player-dashboard.html">Player Dashboard</a>
+          <a href="player-profile.html">Player Profile</a>
+          <a href="team-profile.html">Team Profile</a>
+          <a href="match-center.html">Match Center</a>
+          <a href="event-detail.html">Event Detail</a>
+          <a href="tickets.html">Tickets</a>
+          <a href="support.html">Support</a>
+          <a href="rules.html">Rules</a>
+          <a href="standings.html">Standings</a>
+          <a href="admin-console.html">Admin Console</a>
+          <a href="seeding.html">Seeding</a>
+          <a href="faq.html">FAQ</a>
+        </div>
+        <div class="auth-status" data-auth-status>
+          <a class="btn ghost" href="login.html" data-auth-signin>Sign In</a>
+          <div class="auth-user is-hidden" data-auth-user></div>
+          <button class="btn ghost is-hidden" type="button" data-auth-logout>Sign Out</button>
+        </div>
+      </nav>
+    </header>
+
+    <main class="team-management">
+      <section class="team-hero">
+        <div>
+          <p class="tag">Splatoon 3 • Team Hub</p>
+          <h1>Manage your roster, roles, and match readiness.</h1>
+          <p class="subhead">
+            Keep your squad coordinated with role assignments, availability tracking, and roster
+            lock reminders before the bracket goes live.
+          </p>
+        </div>
+        <div class="team-actions">
+          <button class="btn primary">Invite player</button>
+          <button class="btn secondary">Upload team logo</button>
+        </div>
+      </section>
+
+      <section class="team-grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Roster</h2>
+            <button class="btn ghost">Edit roles</button>
+          </div>
+          <div class="roster-list">
+            <div class="roster-card">
+              <div class="avatar">IK</div>
+              <div>
+                <h3>InkKnight</h3>
+                <p>Captain · Slayer</p>
+              </div>
+              <span class="status-pill open">Confirmed</span>
+            </div>
+            <div class="roster-card">
+              <div class="avatar">SV</div>
+              <div>
+                <h3>Seavolt</h3>
+                <p>Support · Anchor</p>
+              </div>
+              <span class="status-pill">Awaiting</span>
+            </div>
+            <div class="roster-card">
+              <div class="avatar">NY</div>
+              <div>
+                <h3>NeonYuki</h3>
+                <p>Flex · Sub</p>
+              </div>
+              <span class="status-pill open">Confirmed</span>
+            </div>
+            <div class="roster-card">
+              <div class="avatar">TR</div>
+              <div>
+                <h3>TideRunner</h3>
+                <p>Support · Starter</p>
+              </div>
+              <span class="status-pill">Pending</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Team readiness</h2>
+            <button class="btn ghost">Update status</button>
+          </div>
+          <div class="readiness-grid">
+            <div>
+              <h3>Scrim schedule</h3>
+              <p>3 scrims booked · Next: Apr 6</p>
+            </div>
+            <div>
+              <h3>Loadout lock</h3>
+              <p>Due in 4 days</p>
+            </div>
+            <div>
+              <h3>Roster lock</h3>
+              <p>2 players pending</p>
+            </div>
+          </div>
+          <div class="readiness-card">
+            <h3>Upcoming scrims</h3>
+            <ul>
+              <li>Apr 6 · 7:00 PM PT · vs Neon Nautilus</li>
+              <li>Apr 9 · 8:30 PM PT · vs Lagoon Legends</li>
+            </ul>
+            <button class="btn secondary">Manage scrims</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="team-notes">
+        <div>
+          <h2>Team notes</h2>
+          <p>Add match prep notes and highlight key strategies for captains and substitutes.</p>
+        </div>
+        <div class="notes-card">
+          <p>
+            Focus on Rainmaker rotation and mid control. Assign InkKnight to open lanes and keep
+            Seavolt on anchor defense.
+          </p>
+          <button class="btn ghost">Edit notes</button>
+        </div>
+      </section>
+
+      <section class="team-grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Create a team</h2>
+            <span class="pill">API connected</span>
+          </div>
+          <form id="team-create-form" class="stacked-form">
+            <label class="field">
+              <span>Team name</span>
+              <input type="text" name="teamName" placeholder="Lagoon Legends" required />
+            </label>
+            <button class="btn primary" type="submit">Create team</button>
+            <p id="team-create-status" class="helper-text" role="status"></p>
+          </form>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Add a team member</h2>
+            <span class="pill">Captain access</span>
+          </div>
+          <form id="team-member-form" class="stacked-form">
+            <p class="helper-text">Sign in to update rosters with organizer permissions.</p>
+            <label class="field">
+              <span>Team ID</span>
+              <input type="number" name="teamId" placeholder="1" required />
+            </label>
+            <label class="field">
+              <span>User ID</span>
+              <input type="number" name="userId" placeholder="42" required />
+            </label>
+            <label class="field">
+              <span>Role</span>
+              <input type="text" name="role" placeholder="Captain" required />
+            </label>
+            <button class="btn primary" type="submit">Add member</button>
+            <p id="team-member-status" class="helper-text" role="status"></p>
+          </form>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div>
+        <h3>Need to add a substitute?</h3>
+        <p>Roster changes stay open until 48 hours before the event.</p>
+      </div>
+      <button class="btn primary">Request roster update</button>
+    </footer>
+    <script src="auth.js"></script>
+    <script src="team-management.js"></script>
+  </body>
+</html>

--- a/team-management.js
+++ b/team-management.js
@@ -1,0 +1,82 @@
+const createForm = document.querySelector('#team-create-form');
+const createStatus = document.querySelector('#team-create-status');
+const memberForm = document.querySelector('#team-member-form');
+const memberStatus = document.querySelector('#team-member-status');
+const authClient = window.ArcadiaAuth;
+
+const setStatus = (element, message, type = 'info') => {
+  if (!element) {
+    return;
+  }
+  element.textContent = message;
+  if (type === 'error' || type === 'success') {
+    element.dataset.status = type;
+  } else {
+    element.removeAttribute('data-status');
+  }
+};
+
+if (createForm) {
+  createForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!authClient?.getAccessToken()) {
+      setStatus(createStatus, 'Sign in to create a team.', 'error');
+      return;
+    }
+
+    const formData = new FormData(createForm);
+    const teamName = formData.get('teamName')?.toString().trim();
+
+    if (!teamName) {
+      setStatus(createStatus, 'Please enter a team name.', 'error');
+      return;
+    }
+
+    const response = await authClient.authenticatedFetch('/api/teams', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: teamName }),
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      setStatus(createStatus, error?.error ?? 'Unable to create team.', 'error');
+      return;
+    }
+
+    createForm.reset();
+    setStatus(createStatus, 'Team created. Save the Team ID for roster updates.', 'success');
+  });
+}
+
+if (memberForm) {
+  memberForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!authClient?.getAccessToken()) {
+      setStatus(memberStatus, 'Sign in to update the roster.', 'error');
+      return;
+    }
+
+    const formData = new FormData(memberForm);
+    const teamId = formData.get('teamId')?.toString().trim();
+    const userId = formData.get('userId')?.toString().trim();
+    const role = formData.get('role')?.toString().trim();
+
+    const response = await authClient.authenticatedFetch(`/api/teams/${teamId}/members`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ userId, role }),
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      setStatus(memberStatus, error?.error ?? 'Unable to add member.', 'error');
+      return;
+    }
+
+    memberForm.reset();
+    setStatus(memberStatus, 'Member added to the roster.', 'success');
+  });
+}

--- a/team-profile.html
+++ b/team-profile.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Arcadia Clash is a competitive tournament hub for managing brackets, teams, and live matches." />
+    <meta property="og:title" content="Arcadia Clash - Tournament Hub" />
+    <meta property="og:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://arcadiaclash.gg/" />
+    <meta property="og:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Arcadia Clash - Tournament Hub" />
+    <meta name="twitter:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta name="twitter:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <title>Arcadia Clash - Team Profile</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ARCADIA-0001"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-ARCADIA-0001");
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav">
+        <a class="logo" href="index.html">
+          <span class="logo-mark">AC</span>
+          <span class="logo-text">Arcadia Clash</span>
+        </a>
+        <div class="nav-links">
+          <a href="index.html#features">Features</a>
+          <a href="index.html#brackets">Brackets</a>
+          <a href="index.html#schedule">Schedule</a>
+          <a href="index.html#community">Community</a>
+          <a href="signup.html">Tournament Sign Up</a>
+          <a href="user-signup.html">User Sign Up</a>
+          <a href="schedule.html">Schedule List</a>
+          <a href="team-management.html">Team Management</a>
+          <a href="player-dashboard.html">Player Dashboard</a>
+          <a href="player-profile.html">Player Profile</a>
+          <a href="team-profile.html" class="active">Team Profile</a>
+          <a href="match-center.html">Match Center</a>
+          <a href="event-detail.html">Event Detail</a>
+          <a href="tickets.html">Tickets</a>
+          <a href="support.html">Support</a>
+          <a href="rules.html">Rules</a>
+          <a href="standings.html">Standings</a>
+          <a href="admin-console.html">Admin Console</a>
+          <a href="seeding.html">Seeding</a>
+          <a href="faq.html">FAQ</a>
+        </div>
+        <div class="auth-status" data-auth-status>
+          <a class="btn ghost" href="login.html" data-auth-signin>Sign In</a>
+          <div class="auth-user is-hidden" data-auth-user></div>
+          <button class="btn ghost is-hidden" type="button" data-auth-logout>Sign Out</button>
+        </div>
+      </nav>
+    </header>
+
+    <main class="profile">
+      <section class="profile-hero">
+        <div class="profile-card">
+          <div class="profile-avatar">CC</div>
+          <div>
+            <p class="tag">Team Profile</p>
+            <h1>Crimson Circuit</h1>
+            <p class="subhead">#1 Seed · North America · Founded 2021</p>
+          </div>
+          <div class="profile-actions">
+            <button class="btn primary">Follow team</button>
+            <button class="btn secondary">Request scrim</button>
+          </div>
+        </div>
+        <div class="profile-stats">
+          <div>
+            <h3>12-2</h3>
+            <p>Record</p>
+          </div>
+          <div>
+            <h3>1860</h3>
+            <p>Seed points</p>
+          </div>
+          <div>
+            <h3>W6</h3>
+            <p>Streak</p>
+          </div>
+          <div>
+            <h3>68%</h3>
+            <p>Map control</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="profile-grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Roster</h2>
+            <button class="btn ghost">Contact captain</button>
+          </div>
+          <div class="roster-list">
+            <div class="roster-card">
+              <div class="avatar">IK</div>
+              <div>
+                <h3>InkKnight</h3>
+                <p>Captain · Slayer</p>
+              </div>
+              <span class="status-pill open">Active</span>
+            </div>
+            <div class="roster-card">
+              <div class="avatar">SV</div>
+              <div>
+                <h3>Seavolt</h3>
+                <p>Anchor · Support</p>
+              </div>
+              <span class="status-pill open">Active</span>
+            </div>
+            <div class="roster-card">
+              <div class="avatar">NY</div>
+              <div>
+                <h3>NeonYuki</h3>
+                <p>Flex · Starter</p>
+              </div>
+              <span class="status-pill">Sub</span>
+            </div>
+            <div class="roster-card">
+              <div class="avatar">TR</div>
+              <div>
+                <h3>TideRunner</h3>
+                <p>Support · Starter</p>
+              </div>
+              <span class="status-pill open">Active</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Season summary</h2>
+            <button class="btn ghost">View analytics</button>
+          </div>
+          <div class="summary-grid">
+            <div>
+              <h3>2.4</h3>
+              <p>Team K/D</p>
+            </div>
+            <div>
+              <h3>56%</h3>
+              <p>Objective control</p>
+            </div>
+            <div>
+              <h3>14</h3>
+              <p>Matches played</p>
+            </div>
+            <div>
+              <h3>3</h3>
+              <p>LAN appearances</p>
+            </div>
+          </div>
+          <div class="highlight-card">
+            <h3>Featured highlight</h3>
+            <p>Finals recap · 48k views</p>
+            <button class="btn secondary">Watch</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="profile-grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Recent results</h2>
+            <button class="btn ghost">Match history</button>
+          </div>
+          <div class="history-list">
+            <div>
+              <h3>Win · vs Volt Tide</h3>
+              <p>3-1 · Double elimination</p>
+            </div>
+            <div>
+              <h3>Win · vs Lagoon Legends</h3>
+              <p>3-2 · Semifinals</p>
+            </div>
+            <div>
+              <h3>Loss · vs Neon Nautilus</h3>
+              <p>2-3 · Scrim</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Team highlights</h2>
+            <button class="btn ghost">View all</button>
+          </div>
+          <div class="highlight-list">
+            <div class="highlight-card">
+              <h3>Objective control montage</h3>
+              <p>18k views · 3 days ago</p>
+              <button class="btn secondary">Watch</button>
+            </div>
+            <div class="highlight-card">
+              <h3>LAN finals recap</h3>
+              <p>32k views · 2 weeks ago</p>
+              <button class="btn secondary">Watch</button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div>
+        <h3>Book this team for scrims</h3>
+        <p>Reach out to the captain to coordinate practice sessions.</p>
+      </div>
+      <button class="btn primary">Request scrim</button>
+    </footer>
+    <script src="auth.js"></script>
+  </body>
+</html>

--- a/tickets.html
+++ b/tickets.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Arcadia Clash is a competitive tournament hub for managing brackets, teams, and live matches." />
+    <meta property="og:title" content="Arcadia Clash - Tournament Hub" />
+    <meta property="og:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://arcadiaclash.gg/" />
+    <meta property="og:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Arcadia Clash - Tournament Hub" />
+    <meta name="twitter:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta name="twitter:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <title>Arcadia Clash - Tickets & Attendance</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ARCADIA-0001"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-ARCADIA-0001");
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav">
+        <a class="logo" href="index.html">
+          <span class="logo-mark">AC</span>
+          <span class="logo-text">Arcadia Clash</span>
+        </a>
+        <div class="nav-links">
+          <a href="index.html#features">Features</a>
+          <a href="index.html#brackets">Brackets</a>
+          <a href="index.html#schedule">Schedule</a>
+          <a href="index.html#community">Community</a>
+          <a href="signup.html">Tournament Sign Up</a>
+          <a href="user-signup.html">User Sign Up</a>
+          <a href="schedule.html">Schedule List</a>
+          <a href="team-management.html">Team Management</a>
+          <a href="player-dashboard.html">Player Dashboard</a>
+          <a href="player-profile.html">Player Profile</a>
+          <a href="team-profile.html">Team Profile</a>
+          <a href="match-center.html">Match Center</a>
+          <a href="event-detail.html">Event Detail</a>
+          <a href="tickets.html" class="active">Tickets</a>
+          <a href="support.html">Support</a>
+          <a href="rules.html">Rules</a>
+          <a href="standings.html">Standings</a>
+          <a href="admin-console.html">Admin Console</a>
+          <a href="seeding.html">Seeding</a>
+          <a href="faq.html">FAQ</a>
+        </div>
+        <div class="auth-status" data-auth-status>
+          <a class="btn ghost" href="login.html" data-auth-signin>Sign In</a>
+          <div class="auth-user is-hidden" data-auth-user></div>
+          <button class="btn ghost is-hidden" type="button" data-auth-logout>Sign Out</button>
+        </div>
+      </nav>
+    </header>
+
+    <main class="tickets">
+      <section class="tickets-hero">
+        <div>
+          <p class="tag">LAN Finals · Tickets Live</p>
+          <h1>Arcadia Clash Finals: Live Attendance</h1>
+          <p class="subhead">
+            Secure your seat at the Grand Arena for a full weekend of Splatoon 3 finals, meetups, and
+            merch drops.
+          </p>
+        </div>
+        <div class="tickets-actions">
+          <button class="btn primary">Buy tickets</button>
+          <button class="btn secondary">View venue map</button>
+        </div>
+      </section>
+
+      <section class="tickets-grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Venue info</h2>
+            <button class="btn ghost">Get directions</button>
+          </div>
+          <div class="venue-details">
+            <div>
+              <h3>Grand Arena</h3>
+              <p>2300 Main St, Los Angeles, CA</p>
+            </div>
+            <div>
+              <h3>Doors</h3>
+              <p>Open at 10:00 AM · Main stage 12:00 PM</p>
+            </div>
+            <div>
+              <h3>Parking</h3>
+              <p>On-site garage · $15/day</p>
+            </div>
+          </div>
+          <button class="btn secondary">Download venue guide</button>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Ticket tiers</h2>
+            <button class="btn ghost">Compare perks</button>
+          </div>
+          <div class="ticket-cards">
+            <div class="ticket-card">
+              <h3>General Admission</h3>
+              <p class="price">$35</p>
+              <ul>
+                <li>Standard seating</li>
+                <li>Merch booth access</li>
+                <li>Community lounge</li>
+              </ul>
+              <button class="btn ghost">Select</button>
+            </div>
+            <div class="ticket-card highlight">
+              <h3>VIP Pass</h3>
+              <p class="price">$85</p>
+              <ul>
+                <li>Priority seating</li>
+                <li>Meet & greet</li>
+                <li>Exclusive merch bundle</li>
+              </ul>
+              <button class="btn primary">Select</button>
+            </div>
+            <div class="ticket-card">
+              <h3>Weekend Bundle</h3>
+              <p class="price">$60</p>
+              <ul>
+                <li>Two-day access</li>
+                <li>Early entry</li>
+                <li>Badge + lanyard</li>
+              </ul>
+              <button class="btn ghost">Select</button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="tickets-grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Seating map highlights</h2>
+            <button class="btn ghost">View full map</button>
+          </div>
+          <div class="seat-grid">
+            <div>
+              <h3>Section A</h3>
+              <p>Stage-front · 120 seats</p>
+            </div>
+            <div>
+              <h3>Section B</h3>
+              <p>Mid-level · 300 seats</p>
+            </div>
+            <div>
+              <h3>Section C</h3>
+              <p>Upper bowl · 550 seats</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>Weekend agenda</h2>
+            <button class="btn ghost">See full agenda</button>
+          </div>
+          <div class="agenda-list">
+            <div>
+              <h3>Day 1</h3>
+              <p>Player check-in · 10:00 AM</p>
+              <p>Quarterfinals · 12:00 PM</p>
+            </div>
+            <div>
+              <h3>Day 2</h3>
+              <p>Fan meetup · 11:00 AM</p>
+              <p>Grand Finals · 5:00 PM</p>
+            </div>
+          </div>
+          <button class="btn secondary">Add agenda to calendar</button>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div>
+        <h3>Questions about attendance?</h3>
+        <p>Reach out to ticketing@arcadiaclash.gg for support.</p>
+      </div>
+      <button class="btn primary">Contact ticketing</button>
+    </footer>
+    <script src="auth.js"></script>
+  </body>
+</html>

--- a/user-signup.html
+++ b/user-signup.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Arcadia Clash is a competitive tournament hub for managing brackets, teams, and live matches." />
+    <meta property="og:title" content="Arcadia Clash - Tournament Hub" />
+    <meta property="og:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://arcadiaclash.gg/" />
+    <meta property="og:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Arcadia Clash - Tournament Hub" />
+    <meta name="twitter:description" content="Manage teams, brackets, and live matches in one competitive tournament platform." />
+    <meta name="twitter:image" content="https://placehold.co/1200x630/png?text=Arcadia+Clash" />
+    <title>Arcadia Clash - User Sign Up</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ARCADIA-0001"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-ARCADIA-0001");
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav">
+        <a class="logo" href="index.html">
+          <span class="logo-mark">AC</span>
+          <span class="logo-text">Arcadia Clash</span>
+        </a>
+        <div class="nav-links">
+          <a href="index.html#features">Features</a>
+          <a href="index.html#brackets">Brackets</a>
+          <a href="index.html#schedule">Schedule</a>
+          <a href="index.html#community">Community</a>
+          <a href="user-signup.html" class="active">User Sign Up</a>
+          <a href="signup.html">Tournament Sign Up</a>
+          <a href="schedule.html">Schedule List</a>
+          <a href="faq.html">FAQ</a>
+          <a href="team-management.html">Team Management</a>
+          <a href="player-dashboard.html">Player Dashboard</a>
+          <a href="player-profile.html">Player Profile</a>
+          <a href="team-profile.html">Team Profile</a>
+          <a href="match-center.html">Match Center</a>
+          <a href="event-detail.html">Event Detail</a>
+          <a href="tickets.html">Tickets</a>
+          <a href="support.html">Support</a>
+          <a href="rules.html">Rules</a>
+          <a href="standings.html">Standings</a>
+          <a href="admin-console.html">Admin Console</a>
+          <a href="seeding.html">Seeding</a>
+        </div>
+        <div class="auth-status" data-auth-status>
+          <a class="btn ghost" href="login.html" data-auth-signin>Sign In</a>
+          <div class="auth-user is-hidden" data-auth-user></div>
+          <button class="btn ghost is-hidden" type="button" data-auth-logout>Sign Out</button>
+        </div>
+      </nav>
+    </header>
+
+    <main class="auth">
+      <section class="auth-hero">
+        <p class="tag">Create your Arcadia ID</p>
+        <h1>Level up with a player profile.</h1>
+        <p class="subhead">
+          Build your gamer profile, track tournament history, and get personalized event alerts.
+        </p>
+      </section>
+
+      <section class="auth-card">
+        <h2>User sign up</h2>
+        <p class="form-note">All fields required unless marked optional.</p>
+        <form id="user-signup-form">
+          <div class="form-grid">
+            <label>
+              First name
+              <input type="text" name="firstName" placeholder="Jordan" required />
+            </label>
+            <label>
+              Last name
+              <input type="text" name="lastName" placeholder="Park" required />
+            </label>
+          </div>
+          <label>
+            Gamer tag
+            <input type="text" name="gamerTag" placeholder="InkNova" required />
+          </label>
+          <label>
+            Username
+            <input type="text" name="username" placeholder="inknova7" required />
+          </label>
+          <label>
+            Email address
+            <input type="email" name="email" placeholder="you@email.com" required />
+          </label>
+          <div class="form-grid">
+            <label>
+              Password
+              <input type="password" name="password" placeholder="Create a password" required />
+            </label>
+            <label>
+              Confirm password
+              <input type="password" name="confirmPassword" placeholder="Re-enter password" required />
+            </label>
+          </div>
+          <div class="form-grid">
+            <label>
+              Platform
+              <select name="platform" required>
+                <option value="">Select platform</option>
+                <option>Nintendo Switch</option>
+                <option>PC</option>
+                <option>PlayStation</option>
+                <option>Xbox</option>
+              </select>
+            </label>
+            <label>
+              Region
+              <select name="region" required>
+                <option value="">Select region</option>
+                <option>North America</option>
+                <option>Europe</option>
+                <option>Asia Pacific</option>
+                <option>South America</option>
+              </select>
+            </label>
+          </div>
+          <label>
+            Discord handle (optional)
+            <input type="text" name="discord" placeholder="InkNova#1234" />
+          </label>
+          <label class="checkbox">
+            <input type="checkbox" required />
+            I agree to the terms of service and privacy policy.
+          </label>
+          <button class="btn primary full" type="submit">Create account</button>
+          <p id="user-signup-status" class="helper-text" role="status"></p>
+        </form>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div>
+        <h3>Already have an account?</h3>
+        <p>Sign in to manage teams, track brackets, and join live events.</p>
+      </div>
+      <a class="btn secondary" href="login.html">Sign In</a>
+    </footer>
+    <script src="auth.js"></script>
+    <script src="user-signup.js"></script>
+  </body>
+</html>

--- a/user-signup.js
+++ b/user-signup.js
@@ -1,0 +1,55 @@
+const form = document.querySelector('#user-signup-form');
+const statusEl = document.querySelector('#user-signup-status');
+
+const setStatus = (message, type = 'info') => {
+  if (!statusEl) {
+    return;
+  }
+  statusEl.textContent = message;
+  if (type === 'error' || type === 'success') {
+    statusEl.dataset.status = type;
+  } else {
+    statusEl.removeAttribute('data-status');
+  }
+};
+
+if (form) {
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+
+    const formData = new FormData(form);
+    const firstName = formData.get('firstName')?.toString().trim();
+    const lastName = formData.get('lastName')?.toString().trim();
+    const gamerTag = formData.get('gamerTag')?.toString().trim();
+    const email = formData.get('email')?.toString().trim();
+    const password = formData.get('password')?.toString();
+    const confirmPassword = formData.get('confirmPassword')?.toString();
+
+    if (!firstName || !lastName || !gamerTag || !email || !password) {
+      setStatus('Please fill out all required fields.', 'error');
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setStatus('Passwords do not match. Please re-enter them.', 'error');
+      return;
+    }
+
+    const displayName = `${firstName} ${lastName}`;
+
+    const response = await fetch('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, displayName, password }),
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      setStatus(error?.error ?? 'Unable to create account.', 'error');
+      return;
+    }
+
+    form.reset();
+    setStatus('Account created! You can now sign in.', 'success');
+  });
+}


### PR DESCRIPTION
### Motivation
- Provide a parallel, local-first implementation that runs predictably without hidden plugin/decorator registration or implicit ordering. 
- Make it trivial to run the backend locally with a single command and explicit environment configuration. 
- Keep the existing server implementation untouched while providing a clearly separated developer workflow for local testing. 

### Description
- Add a new `local-dev/backend` tree that mirrors the API but centralizes global setup in `local-index.js`, which registers `@fastify/cors`, `@fastify/cookie`, and `@fastify/jwt` exactly once and exposes `authenticate` and `requireRoles` decorators in one place. 
- Provide `local-dev/backend/routes.js` (copied from the main routes) refactored only to consume decorators (`app.authenticate` / `app.requireRoles`) and not register plugins or decorators itself. 
- Include a local SQLite initializer `local-dev/backend/db.js`, a `local-dev/backend/.env.example`, `local-dev/backend/package.json` with `npm run dev`, and `local-dev/README.md` documenting commands and architecture. 
- Preserve the original server code and add complementary server-side artifacts (`server/.env.example`, `server/.env.production.example`, `server/README.md`, and a `smoke-test` script) without modifying the production flow. 

### Testing
- Served the static frontend with `python -m http.server 4173` and verified it responded (automated run; succeeded). 
- Ran a Playwright script that navigated to `http://127.0.0.1:4173/index.html` and captured a screenshot (`artifacts/local-dev-index.png`) to validate the frontend served correctly (succeeded). 
- Queried the local `local-dev/backend` sources with `rg` to confirm plugin and decorator registrations live only in `local-index.js` and that `routes.js` uses `app.requireRoles`/`app.authenticate` (succeeded). 
- No backend process was started against the new local backend during this rollout and the server-side smoke test (`server/scripts/smoke-test.mjs`) was not executed (not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a46451500833189d97cbc644d0641)